### PR TITLE
Preliminar support for long bib strings

### DIFF
--- a/pyoracc/atf/atfyacc.py
+++ b/pyoracc/atf/atfyacc.py
@@ -62,6 +62,7 @@ class AtfParser(object):
                             | ATF USE LEXICAL newline
                             | key_statement
                             | BIB ID newline
+                            | BIB ID EQUALS ID newline
                             | lemmatizer_statement"""
 
     def p_key_statement(self, p):

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -115,6 +115,13 @@ class TestLexer(TestCase):
             ["BIB", "ID", "NEWLINE"]
         )
 
+    def test_bib_long(self):
+        # not documented but common
+        self.compare_tokens(
+            "#bib:  MEE 4 73 = EV a\n",
+            ["BIB", "ID", "EQUALS", "ID", "NEWLINE"]
+        )
+
     def test_link(self):
         self.compare_tokens(
             "#link: def A = P363716 = TCL 06, 44\n" +

--- a/pyoracc/test/model/test_corpus.py
+++ b/pyoracc/test/model/test_corpus.py
@@ -32,5 +32,5 @@ def test_sample():
 def test_whole():
     corpus = Corpus(source=whole_corpus())
     # there is a total of 2868 files in the corpus
-    assert corpus.successes == 2582
-    assert corpus.failures == 286
+    assert corpus.successes == 2613
+    assert corpus.failures == 255


### PR DESCRIPTION
Of the form `#bib:  MEE 4 73 = EV a\n` They are just dropped in the parser as the regular ones but don't cause any failures anymore.
