### PR TITLE
Syntax error format

### DIFF
--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -251,14 +251,16 @@ class AtfLexer(object):
             t.lexer.push_state('flagged')
         if t.type is None:
             formatstring = u"Illegal @STRING '{}'".format(t.value)
+            valuestring = t.value
             if _pyversion() == 2:
                 formatstring = formatstring.encode('UTF-8')
+                valuestring = valuestring.encode('UTF-8')
             if self.skipinvalid:
                 warnings.warn(formatstring, UserWarning)
                 return
             else:
                 raise SyntaxError(formatstring,
-                                  (None, t.lineno, t.lexpos, t.value[0]))
+                                  (None, t.lineno, t.lexpos, valuestring))
         return t
 
     def t_labeled_OPENR(self, t):
@@ -291,14 +293,16 @@ class AtfLexer(object):
             t.lexer.push_state('para')
         if t.type is None:
             formatstring = u"Illegal #STRING '{}'".format(t.value)
+            valuestring = t.value
             if _pyversion() == 2:
                 formatstring = formatstring.encode('UTF-8')
+                valuestring = valuestring.encode('UTF-8')
             if self.skipinvalid:
                 warnings.warn(formatstring, UserWarning)
                 return
             else:
                 raise SyntaxError(formatstring,
-                                  (None, t.lineno, t.lexpos, t.value[0]))
+                                  (None, t.lineno, t.lexpos, valuestring))
         return t
 
     def t_LINELABEL(self, t):
@@ -556,13 +560,16 @@ class AtfLexer(object):
     # Error handling rule
     def t_ANY_error(self, t):
         fstring = u"PyOracc got an illegal character '{}'".format(t.value[0])
+        valuestring = t.value
         if _pyversion() == 2:
             fstring = fstring.encode('UTF-8')
+            valuestring = valuestring.encode('UTF-8')
         if self.skipinvalid:
-            t.lexer.skip(1)
             warnings.warn(fstring, UserWarning)
+            return
         else:
-            raise SyntaxError(fstring, (None, t.lineno, t.lexpos, t.value[0]))
+            raise SyntaxError(fstring,
+                              (None, t.lineno, t.lexpos, valuestring))
 
     def __init__(self, skipinvalid=False, debug=0):
         self.skipinvalid = skipinvalid

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -565,6 +565,7 @@ class AtfLexer(object):
             fstring = fstring.encode('UTF-8')
             valuestring = valuestring.encode('UTF-8')
         if self.skipinvalid:
+            t.lexer.skip(1)
             warnings.warn(fstring, UserWarning)
             return
         else:

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -257,7 +257,8 @@ class AtfLexer(object):
                 warnings.warn(formatstring, UserWarning)
                 return
             else:
-                raise SyntaxError(formatstring)
+                raise SyntaxError(formatstring,
+                                  (None, t.lineno, t.lexpos, t.value[0]))
         return t
 
     def t_labeled_OPENR(self, t):
@@ -296,7 +297,8 @@ class AtfLexer(object):
                 warnings.warn(formatstring, UserWarning)
                 return
             else:
-                raise SyntaxError(formatstring)
+                raise SyntaxError(formatstring,
+                                  (None, t.lineno, t.lexpos, t.value[0]))
         return t
 
     def t_LINELABEL(self, t):
@@ -560,7 +562,7 @@ class AtfLexer(object):
             t.lexer.skip(1)
             warnings.warn(fstring, UserWarning)
         else:
-            raise SyntaxError(fstring)
+            raise SyntaxError(fstring, (None, t.lineno, t.lexpos, t.value[0]))
 
     def __init__(self, skipinvalid=False, debug=0):
         self.skipinvalid = skipinvalid

--- a/pyoracc/atf/atfyacc.py
+++ b/pyoracc/atf/atfyacc.py
@@ -825,9 +825,13 @@ class AtfParser(object):
     )
 
     def p_error(self, p):
-        formatstring = u"PyOracc could not parse token '{}'".format(p)
+        formatstring = u"PyOracc could not parse token '{}'.".format(p)
+        valuestring = p.value
         if _pyversion() == 2:
             formatstring = formatstring.encode('UTF-8')
-        raise SyntaxError(formatstring)
+            valuestring = valuestring.encode('UTF-8')
+        raise SyntaxError(formatstring,
+                          (None, p.lineno, p.lexpos, valuestring))
         # All errors currently unrecoverable
         # So just throw
+        # Add list of params so PyORACC users can build their own error msgs.


### PR DESCRIPTION
Please merge #64 first.
This is useful for Nammu to print error messages with easier to read information for the user to locate the error. 