### PR TITLE
travis: Use the default osx image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
         $PIP install setuptools
         $PIP install ply pep8 mako
         if [ "$MYPYTHON" != "jython" ]; then
-          $PIP install pytest pytest-cov codecov
+          $PIP install --upgrade pytest pytest-cov codecov
         fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
       if [ "$MYPYTHON" == "jython" ]; then
         py.test
       else
-        py.test --cov=pyoracc --cov-report xml --cov-report html --runslow
+        pytest --cov=pyoracc --runslow
       fi
 
   - pep8 --exclude=parsetab.py .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
       sudo: false
       python: 3.5
     - os: osx
-      osx_image: xcode7.3
       language: generic
       env: PIP=pip3 MYPYTHON=python3
 env:


### PR DESCRIPTION
XCode 7.3 (based on macOS 10.11) is out of support, and cannot
complete tests because the `brew upgrade` step has so many
packages to build. Use the default image instead, which is
currently macOS 10.13 and Xcode 9.4.1.

This seems to resolve the recent travis test failures on macOS.