### PR TITLE
json serialization

### DIFF
--- a/pyoracc/atf/common/atffile.py
+++ b/pyoracc/atf/common/atffile.py
@@ -21,6 +21,7 @@ import codecs
 import sys
 import logging
 import json
+from numbers import Number
 
 from pyoracc.atf.cdli.atflex import AtfCDLILexer
 from pyoracc.atf.cdli.atfyacc import AtfCDLIParser
@@ -92,7 +93,7 @@ class AtfFile(object):
             return {k: v
                     for k, v in vars(obj).items()
                     if not str(k).startswith('_') and not (
-                        skip_empty and not v and not isinstance(v, bool)
+                        skip_empty and not v and not isinstance(v, Number)
                     )}
 
         kwargs.setdefault('indent', 2)

--- a/pyoracc/atf/common/atffile.py
+++ b/pyoracc/atf/common/atffile.py
@@ -20,6 +20,7 @@ along with PyORACC. If not, see <http://www.gnu.org/licenses/>.
 import codecs
 import sys
 import logging
+import json
 
 from pyoracc.atf.cdli.atflex import AtfCDLILexer
 from pyoracc.atf.cdli.atfyacc import AtfCDLIParser
@@ -71,6 +72,33 @@ class AtfFile(object):
 
     def serialize(self):
         return AtfFile.template.render_unicode(**vars(self))
+
+    def to_json(self, skip_empty=True, **kwargs):
+        '''Return a JSON representation of the parsed file.
+
+        The optional skip_empty argument determines whether keys
+        with empty values are included in the output. Set it to
+        False to see all possible object members.
+
+        Otherwise it accepts the same optional arguments as
+        json.dumps().'''
+        def _make_serializable(obj):
+            '''Construct a dict representation of an object.
+
+            This is necessary to handle our custom objects
+            which json.JSONEncoder doesn't know how to
+            serialize.'''
+
+            return {k: v
+                    for k, v in vars(obj).items()
+                    if not str(k).startswith('_') and not (
+                        skip_empty and not v and not isinstance(v, bool)
+                    )}
+
+        kwargs.setdefault('indent', 2)
+        kwargs.setdefault('sort_keys', True)
+        kwargs.setdefault('default', _make_serializable)
+        return json.dumps(self.text, **kwargs)
 
 
 def check_atf(infile, atftype, verbose=False):

--- a/pyoracc/atf/common/atffile.py
+++ b/pyoracc/atf/common/atffile.py
@@ -96,7 +96,6 @@ class AtfFile(object):
                     )}
 
         kwargs.setdefault('indent', 2)
-        kwargs.setdefault('sort_keys', True)
         kwargs.setdefault('default', _make_serializable)
         return json.dumps(self.text, **kwargs)
 

--- a/pyoracc/test/atf/test_atffile.py
+++ b/pyoracc/test/atf/test_atffile.py
@@ -21,6 +21,7 @@ along with PyORACC. If not, see <http://www.gnu.org/licenses/>.
 from pyoracc.atf.common.atffile import AtfFile
 from ..fixtures import anzu, belsunu, sample_file
 import pytest
+import json
 
 
 def test_create():
@@ -108,3 +109,18 @@ def test_text_designation(name, code, description):
     afile = AtfFile(sample_file(name))
     assert afile.text.code == code
     assert afile.text.description == description
+
+
+@pytest.mark.parametrize('name', [text[0] for text in texts])
+def test_json_serialization(name):
+    """
+    Parses ATF and verifies the to_json() method output.
+    """
+    afile = AtfFile(sample_file(name))
+    js = afile.to_json()
+    result = json.loads(js)
+    assert result
+    noskipjs = afile.to_json(skip_empty=False)
+    result = json.loads(noskipjs)
+    assert result
+    assert len(noskipjs) >= len(js)

--- a/pyoracc/test/atf/test_atffile.py
+++ b/pyoracc/test/atf/test_atffile.py
@@ -111,7 +111,19 @@ def test_text_designation(name, code, description):
     assert afile.text.description == description
 
 
-@pytest.mark.parametrize('name', [text[0] for text in texts])
+# ATF filenames which fail the serialization tests.
+_xfail_texts = [
+    # Multilingual objects store the unmarked language
+    # under the `None` key in their `lines` dictionary,
+    # which is incompatible with `sort_keys=True`.
+    'bb_2_6',
+    ]
+
+
+@pytest.mark.parametrize('name', [
+    name if name not in _xfail_texts
+    else pytest.param(name, marks=[pytest.mark.xfail()])
+    for name in [text[0] for text in texts]])
 def test_json_serialization(name):
     """
     Parses ATF and verifies the to_json() method output.
@@ -120,7 +132,7 @@ def test_json_serialization(name):
     js = afile.to_json()
     result = json.loads(js)
     assert result
-    noskipjs = afile.to_json(skip_empty=False)
+    noskipjs = afile.to_json(skip_empty=False, sort_keys=True)
     result = json.loads(noskipjs)
     assert result
     assert len(noskipjs) >= len(js)


### PR DESCRIPTION
I wrote this to see what kind of syntax tree the parser was producing, and it took me a while to understand how, since [json.dump()](https://docs.python.org/3/library/json.html?highlight=json#basic-usage) from the standard library doesn't work on general Python objects. I thought it worth including for those reasons, and as a useful way to import tablet data into other tools.

```python
# Usage example.

from pyoracc.atf.common.atffile import AtfFile

with open('example.atf') as f:
  atf = AtfFile(f.read())
  print(atf.to_json())
```

It currently produces a "flat" serialization without object names, which I found most useful for exploring. If there's interest in adding parsing (being able to import json and serialize it back into ATF) that would probably need to change.

The `to_json` method is general, so it would be nice to be able to call it on any of the tree objects. The easiest way to do that would be to add it to `oraccobject` and then make all the objects in the `model` hierarchy inherit from that.

The `to_json` method passes optional arguments on to `json.dump()`, but there's a problem with `sort_keys`. The `Multilingual` objects store the unmarked language lines in a dictionary under `None` which can't be sorted with respect to the other strings. I've just left this as an xfail in the tests, since it's not the default. If you want to address this I can suggest changing the parser to substitute the overall language code of the tablet, or the empty string, or copying the whole tree and making a similar substitution before serializing. The latter would be expensive on corpus objects.

**NB** Currently includes changes from #77 which I hope will be merged first, and from #79 to make the tests pass.