### PR TITLE
Fix remaining travis warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ install:
         fi
         $PIP install wheel
         $PIP install setuptools
-        $PIP install ply pep8 mako
+        $PIP install ply mako
+        $PIP install pycodestyle
         if [ "$MYPYTHON" != "jython" ]; then
           $PIP install --upgrade pytest pytest-cov codecov
         fi
@@ -72,7 +73,7 @@ script:
         pytest --cov=pyoracc
       fi
 
-  - pep8 --exclude=parsetab.py .
+  - pycodestyle --exclude=parsetab.py
   
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
       $MYPYTHON -c "from pyoracc import _generate_parsetab; _generate_parsetab()"
       echo "Running tests"
       if [ "$MYPYTHON" == "jython" ]; then
-        py.test
+        pytest
       else
         pytest --cov=pyoracc
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,6 @@ before_install:
           jython -c "print ''";
           jython -c "import sys; print sys.version"
         fi
-        if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-          brew update
-          brew upgrade
-          brew upgrade python
-          brew install python3
-          python3 --version
-        fi
 
 install:
     - |

--- a/pyoracc/atf/common/atflex.py
+++ b/pyoracc/atf/common/atflex.py
@@ -225,7 +225,7 @@ class AtfLexer(object):
         return t
 
     def t_ID(self, t):
-        u'[a-zA-Z0-9][a-zA-Z\'\u2019\xb4\/\.0-9\:\-\[\]_\u2080-\u2089]*'
+        r'[a-zA-Z0-9][a-zA-Z0-9/.:_\-\[\]' u'\'\u2019\xb4\u2080-\u2089]*'
         t.value = t.value.replace(u'\u2019', "'")
         t.value = t.value.replace(u'\xb4', "'")
         t.type = self.resolve_keyword(t.value,
@@ -271,7 +271,7 @@ class AtfLexer(object):
     # Unicode 2032  is PRIME
     # All of these could be used as prime
     def t_transctrl_ID(self, t):
-        u'[a-zA-Z0-9][a-zA-Z\'\u2019\u2032\u02CA\xb4\/\.0-9\:\-\[\]_' \
+        r'[a-zA-Z0-9][a-zA-Z0-9/.:_\-\[\]' u'\'\u2019\u2032\u02CA\xb4' \
             u'\u2080-\u2089]*'
         t.value = t.value.replace(u'\u2019', "'")
         t.value = t.value.replace(u'\u2032', "'")
@@ -409,7 +409,7 @@ class AtfLexer(object):
     # Free text, ended by double new line
 
     terminates_para = \
-        "(\#|\@[^i][^\{]|\&|\Z|(^[0-9]+[\'\u2019\u2032\u02CA\xb4]?\.))"
+        r'(#|@[^i][^{]|&|\Z|(^[0-9]+' u'[\'\u2019\u2032\u02CA\xb4]\\.))'
 
     @lex.TOKEN(r'([^\^\n\r]|(\r?\n(?!\s*\r?\n)(?!' +
                terminates_para + ')))+')

--- a/pyoracc/atf/common/atflex.py
+++ b/pyoracc/atf/common/atflex.py
@@ -416,7 +416,6 @@ class AtfLexer(object):
     def t_para_ID(self, t):
         t.lexer.lineno += t.value.count("\n")
         t.value = t.value.strip()
-        print(' *** in t_para_ID with value', t.value, ' ***')
         return t
 
     # Paragraph state is ended by a double newline

--- a/pyoracc/atf/common/atflex.py
+++ b/pyoracc/atf/common/atflex.py
@@ -69,16 +69,16 @@ class AtfLexer(object):
 
     states = AtfLexicon.STATES
 
-    t_AMPERSAND = r'\&'
-    t_HASH = r'\#'
-    t_EXCLAIM = r'\!'
+    t_AMPERSAND = r'&'
+    t_HASH = r'#'
+    t_EXCLAIM = r'!'
     t_QUERY = r'\?'
     t_STAR = r'\*'
     t_DOLLAR = r'\$'
-    t_MINUS = r'\-'
-    t_FROM = r'\<\<'
-    t_TO = r'\>\>'
-    t_COMMA = r'\,'
+    t_MINUS = r'-'
+    t_FROM = r'<<'
+    t_TO = r'>>'
+    t_COMMA = r','
     t_PARBAR = r'\|\|'
 
     t_INITIAL_transctrl_PARENTHETICALID = r'\([^\n\r]*\)'
@@ -88,22 +88,22 @@ class AtfLexer(object):
         # NO TOKEN
 
     def t_MULTILINGUAL(self, t):
-        r'\=\='
+        r'=='
         t.lexer.push_state("text")
         return t
 
     def t_EQUALBRACE(self, t):
-        r'^\=\{'
+        r'^=\{'
         t.lexer.push_state('text')
         return t
 
     def t_EQUALS(self, t):
-        r'\='
+        r'='
         t.lexer.push_state('flagged')
         return t
 
     def t_INITIAL_parallel_labeled_COMMENT(self, t):
-        r'^\#+(?![a-zA-Z]+\:)'
+        r'^#+(?![a-zA-Z]+:)'
         # Negative lookahead to veto protocols as comments
         t.lexer.push_state('absorb')
         return t
@@ -121,7 +121,7 @@ class AtfLexer(object):
         return t
 
     def t_INITIAL_parallel_labeled_ATID(self, t):
-        r'^\@[a-zA-Z][a-zA-Z0-9\[\]]*\+?'
+        r'^@[a-zA-Z][a-zA-Z0-9\[\]]*\+?'
         t.value = t.value[1:]
         t.lexpos += 1
         t.type = self.resolve_keyword(t.value,
@@ -171,13 +171,13 @@ class AtfLexer(object):
         return t
 
     def t_labeled_OPENR(self, t):
-        r'\@\('
+        r'@\('
         t.lexer.push_state("para")
         t.lexer.push_state("transctrl")
         return t
 
     def t_INITIAL_parallel_labeled_HASHID(self, t):
-        r'\#[a-zA-Z][a-zA-Z0-9\[\]]+\:'
+        r'#[a-zA-Z][a-zA-Z0-9\[\]]+:'
         # Note that \:? absorbs a trailing colon in protocol keywords
         t.value = t.value[1:-1]
         t.lexpos += 1
@@ -213,13 +213,13 @@ class AtfLexer(object):
         return t
 
     def t_LINELABEL(self, t):
-        r'^[^\ \t\n]*\.'
+        r'^[^ \t\n]*\.'
         t.value = t.value[:-1]
         t.lexer.push_state('text')
         return t
 
     def t_score_SCORELABEL(self, t):
-        r'^[^.:\ \t\#][^.:\ \t]*\:'
+        r'^[^.: \t#][^.: \t]*:'
         t.value = t.value[:-1]
         t.lexer.push_state('text')
         return t
@@ -306,7 +306,7 @@ class AtfLexer(object):
     t_parallel_QUERY = r'\?'
 
     def t_parallel_LINELABEL(self, t):
-        r'^([^\.\ \t]*)\.[\ \t]*'
+        r'^([^. \t]*)\.[ \t]*'
         t.value = t.value.strip(" \t.")
         return t
 
@@ -315,7 +315,7 @@ class AtfLexer(object):
         t.lexer.push_state("absorb")
         return t
 
-    t_transctrl_MINUS = r'\-\ '
+    t_transctrl_MINUS = r'- '
 
     def t_transctrl_CLOSER(self, t):
         r'\)'
@@ -347,12 +347,12 @@ class AtfLexer(object):
     # Flag characters (#! etc ) don't apply in translations
     # But reference anchors ^1^ etc do.
     # lines beginning with a space are continuations
-    white = r'[\ \t]*'
+    white = r'[ \t]*'
     # translation_regex1 and translation_regex2 are identical appart from the
     # fact that the first character may not be a ?
     # We are looking for a string that does not start with ? it may include
     # newlines if they are followed by a whitespace.
-    translation_regex1 = r'([^\?\^\n\r]|([\n\r](?=[ \t])))'
+    translation_regex1 = r'([^?\^\n\r]|([\n\r](?=[ \t])))'
     translation_regex2 = r'([^\^\n\r]|([\n\r](?=[ \t])))*'
     translation_regex = white + translation_regex1 + translation_regex2 + white
 
@@ -366,7 +366,7 @@ class AtfLexer(object):
         return t
 
     def t_parallel_labeled_AMPERSAND(self, t):
-        r'\&'
+        r'&'
         # New document, so leave translation state
         t.lexer.pop_state()
         return t
@@ -383,9 +383,9 @@ class AtfLexer(object):
     # Used for states where only flag# characters! and ^1^ references
     # Are separately tokenised
 
-    nonflagnonwhite = r'[^\ \t\#\!\^\*\?\n\r\=]'
-    internalonly = r'[^\n\^\r\=]'
-    nonflag = r'[^\ \t\#\!\^\*\?\n\r\=]'
+    nonflagnonwhite = r'[^ \t#!\^*?\n\r=]'
+    internalonly = r'[^\n\^\r=]'
+    nonflag = r'[^ \t#!\^*?\n\r=]'
     many_int_then_nonflag = '(' + internalonly + '*' + nonflag + '+' + ')'
     many_nonflag = nonflag + '*'
     intern_or_nonflg = '(' + many_int_then_nonflag + '|' + many_nonflag + ')'
@@ -399,12 +399,12 @@ class AtfLexer(object):
         t.value = t.value.strip()
         return t
 
-    t_flagged_HASH = r'\#'
-    t_flagged_EXCLAIM = r'\!'
+    t_flagged_HASH = r'#'
+    t_flagged_EXCLAIM = r'!'
     t_flagged_QUERY = r'\?'
     t_flagged_STAR = r'\*'
-    t_flagged_parallel_para_HAT = r'[\ \t]*\^[\ \t]*'
-    t_flagged_EQUALS = r'\='
+    t_flagged_parallel_para_HAT = r'[ \t]*\^[ \t]*'
+    t_flagged_EQUALS = r'='
     # --- Rules for paragaph state----------------------------------
     # Free text, ended by double new line
 
@@ -441,11 +441,11 @@ class AtfLexer(object):
     # --- RULES FOR THE nonequals STATE -----
     # Absorb everything except an equals
     def t_nonequals_ID(self, t):
-        r'[^\=\n\r]+'
+        r'[^=\n\r]+'
         t.value = t.value.strip()
         return t
 
-    t_nonequals_EQUALS = r'\='
+    t_nonequals_EQUALS = r'='
 
     # --- RULES FOR THE absorb STATE -----
     # Absorb everything
@@ -455,15 +455,15 @@ class AtfLexer(object):
         return t
 
     # --- RULES FOR THE text STATE ----
-    t_text_ID = r'[^\ \t \n\r]+'
+    t_text_ID = r'[^ \t\n\r]+'
 
     def t_text_SPACE(self, t):
-        r'[\ \t]'
+        r'[ \t]'
         # No token generated
 
     # --- RULES FOR THE lemmatize STATE
-    t_lemmatize_ID = r'[^\;\n\r]+'
-    t_lemmatize_SEMICOLON = r'\;[\ \t]*'
+    t_lemmatize_ID = r'[^;\n\r]+'
+    t_lemmatize_SEMICOLON = r';[ \t]*'
 
     # Error handling rule
     def t_ANY_error(self, t):

--- a/pyoracc/atf/common/atflex.py
+++ b/pyoracc/atf/common/atflex.py
@@ -409,13 +409,14 @@ class AtfLexer(object):
     # Free text, ended by double new line
 
     terminates_para = \
-        r'(#|@[^i][^{]|&|\Z|(^[0-9]+' u'[\'\u2019\u2032\u02CA\xb4]\\.))'
+        r'(#|@[^i][^{]|&|\Z|(^[0-9]+' u'[\'\u2019\u2032\u02CA\xb4]?\\.))'
 
     @lex.TOKEN(r'([^\^\n\r]|(\r?\n(?!\s*\r?\n)(?!' +
                terminates_para + ')))+')
     def t_para_ID(self, t):
         t.lexer.lineno += t.value.count("\n")
         t.value = t.value.strip()
+        print(' *** in t_para_ID with value', t.value, ' ***')
         return t
 
     # Paragraph state is ended by a double newline
@@ -428,9 +429,9 @@ class AtfLexer(object):
     # BUT, exceptionally to fix existing bugs in active members of corpus,
     # it is also ended by an @label or an @(), or a new document,
     # Or a linelabel, or the end of the stream. Importantly it does not end
-    # by @i{xxx} which is used for un translated words.
-    # and these tokens are not absorbed by this token
-    # Translation paragraph state is ended by a double newline
+    # by @i{xxx} which is used for untranslated words.
+    # Those tokens are not absorbed by this token.
+    # Translation paragraph state is ended by a double newline.
     @lex.TOKEN(r'\r?\n(?=' + terminates_para + ')')
     def t_para_MAGICNEWLINE(self, t):
         t.lexer.lineno += t.value.count("\n")

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -916,11 +916,11 @@ class TestLexer(TestCase):
         line2 = u"a-kal-ši-na ṭi-id-di"
         # Generate the successive line numbers in the same style.
         label1 = line_label
-        next = int(label1[:1]) + 1
+        next_label = int(label1[:1]) + 1
         if _pyversion() == 2:
-            label2 = unicode(next) + label1[1:]
+            label2 = unicode(next_label) + label1[1:]
         else:
-            label2 = str(next) + label1[1:]
+            label2 = str(next_label) + label1[1:]
         self.compare_tokens(
             label1 + ". " + line1 + "\n" +
             "#note: Does this combine with the next line?\n" +

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -574,6 +574,19 @@ class TestLexer(TestCase):
              "LINELABEL"] + ["ID"] * 6 + ["NEWLINE", "NOTE", "ID", "NEWLINE"]
         )
 
+    def test_hash_note_multiline(self):
+        # Notes can be free text until a double-newline.
+        line = "a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
+        self.compare_tokens(
+            "1. " + line + "\n" +
+            "#note: Does this combine with the next line?\n"
+            "It should.\n\n",
+            ["LINELABEL"] + ["ID"] * len(line.split()) + ["NEWLINE"] +
+            ["NOTE", "ID", "NEWLINE"],
+            ['1'] + line.split() +
+            [None, None, "Does this combine with the next line?\nIt should."]
+        )
+
     def test_open_text_with_dots(self):
         # This must not come out as a linelabel of Hello.
         self.compare_tokens(

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -912,11 +912,15 @@ class TestLexer(TestCase):
     def compare_note_ended_by_line(self, line_label):
         'Helper for Note para state termination.'
         # Sample text.
-        line1 = "a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
-        line2 = "a-kal-ši-na ṭi-id-di"
+        line1 = u"a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
+        line2 = u"a-kal-ši-na ṭi-id-di"
         # Generate the successive line numbers in the same style.
         label1 = line_label
-        label2 = str(int(label1[:1]) + 1) + label1[1:]
+        next = int(label1[:1]) + 1
+        if _pyversion() == 2:
+            label2 = unicode(next) + label1[1:]
+        else:
+            label2 = str(next) + label1[1:]
         self.compare_tokens(
             label1 + ". " + line1 + "\n" +
             "#note: Does this combine with the next line?\n" +

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -909,6 +909,36 @@ class TestLexer(TestCase):
             ["REVERSE"]
         )
 
+    def compare_note_ended_by_line(self, line_label):
+        'Helper for Note para state termination.'
+        # Sample text.
+        line1 = "a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
+        line2 = "a-kal-ši-na ṭi-id-di"
+        # Generate the successive line numbers in the same style.
+        label1 = line_label
+        label2 = str(int(label1[:1]) + 1) + label1[1:]
+        self.compare_tokens(
+            label1 + ". " + line1 + "\n" +
+            "#note: Does this combine with the next line?\n" +
+            label2 + ". " + line2 + "\n",
+            ["LINELABEL"] + ["ID"] * len(line1.split()) + ["NEWLINE"] +
+            ["NOTE", "ID", "NEWLINE"] +
+            ["LINELABEL"] + ["ID"] * len(line2.split()) + ["NEWLINE"],
+            [label1] + line1.split() +
+            [None, None, "Does this combine with the next line?", None] +
+            [label2] + line2.split() + [None]
+        )
+
+    def test_note_ended_by_line(self):
+        'Notes can be free text until the next line label.'
+        for label in ["1",
+                      "2'",
+                      u"3\u2019",
+                      u"4\u2032",
+                      u"5\u02CA",
+                      u"6\xb4"]:
+            self.compare_note_ended_by_line(label)
+
     def test_milestone(self):
         self.compare_tokens(
             "@tablet\n" +


### PR DESCRIPTION
Address the remaining escape sequence warnings, and replace deprecated `pep8` with `pycodestyle`.

Closes #78 .