### PR TITLE
Test on Python 3.7 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
-sudo: false
-
+dist: xenial  # required for Python >= 3.7.
 language: python
 
 matrix:
   include:
     - os: linux
-      sudo: false
       python: 2.7
     - os: linux
-      sudo: false
       python: 2.7
       env: MYPYTHON=jython - JYTHON_URL="https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.1/jython-installer-2.7.1.jar"
     - os: linux
-      sudo: false
       python: 3.5
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.8-dev
     - os: osx
       language: generic
       env: PIP=pip3 MYPYTHON=python3

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -30,14 +30,9 @@ else:
     from itertools import zip_longest
 
 
-@pytest.fixture
-def lexer():
-    """AtfLexer instance used by each test."""
-    return AtfLexer().lexer
-
-
-def compare_tokens(lexer, content, expected_types, expected_values=None,
+def compare_tokens(content, expected_types, expected_values=None,
                    expected_lineno=None, expected_lexpos=None):
+    lexer = AtfLexer().lexer
     lexer.input(content)
     if expected_values is None:
         expected_values = repeat(None)
@@ -62,7 +57,8 @@ def compare_tokens(lexer, content, expected_types, expected_values=None,
             assert token.lexpos == e_lexpos
 
 
-def ensure_raises_and_not(lexer, string, nwarnings):
+def ensure_raises_and_not(string, nwarnings):
+    lexer = AtfLexer().lexer
     lexer.input(string)
     with pytest.raises(SyntaxError) as excinfo:
         for i in lexer:
@@ -76,18 +72,16 @@ def ensure_raises_and_not(lexer, string, nwarnings):
     assert len(record) == nwarnings
 
 
-def test_code(lexer):
+def test_code():
     compare_tokens(
-        lexer,
         "&X001001 = JCS 48, 089\n",
         ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"],
         [None, "X001001", None, "JCS 48, 089"]
     )
 
 
-def test_crlf(lexer):
+def test_crlf():
     compare_tokens(
-        lexer,
         "&X001001 = JCS 48, 089\r\n" +
         "#project: cams/gkab\n\r",
         ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
@@ -95,77 +89,68 @@ def test_crlf(lexer):
     )
 
 
-def test_project(lexer):
+def test_project():
     compare_tokens(
-        lexer,
         "#project: cams/gkab\n",
         ["PROJECT", "ID", "NEWLINE"],
         [None, "cams/gkab", None]
     )
 
 
-def test_key(lexer):
+def test_key():
     compare_tokens(
-        lexer,
         "#key: cdli=ND 02688\n",
         ["KEY", "ID", "EQUALS", "ID", "NEWLINE"],
         [None, "cdli", None, "ND 02688", None]
     )
 
 
-def test_language_protocol(lexer):
+def test_language_protocol():
     compare_tokens(
-        lexer,
         "#atf: lang akk-x-stdbab\n",
         ["ATF", "LANG", "ID", "NEWLINE"],
         [None, None, "akk-x-stdbab"]
     )
 
 
-def test_use_unicode(lexer):
+def test_use_unicode():
     compare_tokens(
-        lexer,
         "#atf: use unicode\n",
         ["ATF", "USE", "UNICODE", "NEWLINE"]
     )
 
 
-def test_use_math(lexer):
+def test_use_math():
     compare_tokens(
-        lexer,
         "#atf: use math\n",
         ["ATF", "USE", "MATH", "NEWLINE"]
     )
 
 
-def test_use_legacy(lexer):
+def test_use_legacy():
     compare_tokens(
-        lexer,
         "#atf: use legacy\n",
         ["ATF", "USE", "LEGACY", "NEWLINE"]
     )
 
 
-def test_bib(lexer):
+def test_bib():
     compare_tokens(
-        lexer,
         "#bib:  MEE 15 54\n",
         ["BIB", "ID", "NEWLINE"]
     )
 
 
-def test_bib_long(lexer):
+def test_bib_long():
     # not documented but common
     compare_tokens(
-        lexer,
         "#bib:  MEE 4 73 = EV a\n",
         ["BIB", "ID", "EQUALS", "ID", "NEWLINE"]
     )
 
 
-def test_link(lexer):
+def test_link():
     compare_tokens(
-        lexer,
         "#link: def A = P363716 = TCL 06, 44\n" +
         "@tablet\n",
         ["LINK", "DEF", "ID", "EQUALS", "ID", "EQUALS", "ID", "NEWLINE",
@@ -174,9 +159,8 @@ def test_link(lexer):
     )
 
 
-def test_link_parallel_slash(lexer):
+def test_link_parallel_slash():
     compare_tokens(
-        lexer,
         "#link: parallel dcclt/obale:P274929 = IM 070209\n" +
         "@tablet\n",
         ["LINK", "PARALLEL", "ID", "EQUALS", "ID", "NEWLINE",
@@ -185,9 +169,8 @@ def test_link_parallel_slash(lexer):
     )
 
 
-def test_link_parallel(lexer):
+def test_link_parallel():
     compare_tokens(
-        lexer,
         "#link: parallel abcd:P363716 = TCL 06, 44\n" +
         "@tablet\n",
         ["LINK", "PARALLEL", "ID", "EQUALS", "ID", "NEWLINE",
@@ -196,111 +179,98 @@ def test_link_parallel(lexer):
     )
 
 
-def test_link_reference(lexer):
+def test_link_reference():
     compare_tokens(
-        lexer,
         "|| A o ii 10\n",
         ["PARBAR", "ID", "ID", "ID", "ID", "NEWLINE"]
     )
 
 
-def test_link_reference_range(lexer):
+def test_link_reference_range():
     compare_tokens(
-        lexer,
         "|| A o ii 10 -  o ii 12 \n",
         ["PARBAR", "ID", "ID", "ID", "ID", "MINUS",
          "ID", "ID", "ID", "NEWLINE"]
     )
 
 
-def test_link_reference_prime_range(lexer):
+def test_link_reference_prime_range():
     compare_tokens(
-        lexer,
         "|| A o ii 10' -  o ii' 12 \n",
         ["PARBAR", "ID", "ID", "ID", "ID", "MINUS",
          "ID", "ID", "ID", "NEWLINE"]
     )
 
 
-def test_score(lexer):
+def test_score():
     compare_tokens(
-        lexer,
         "@score matrix parsed word\n",
         ["SCORE", "ID", "ID", "ID", "NEWLINE"]
     )
 
 
-def test_division_tablet(lexer):
+def test_division_tablet():
     compare_tokens(
-        lexer,
         "@tablet",
         ["TABLET"]
     )
 
 
-def test_text_linenumber(lexer):
+def test_text_linenumber():
     compare_tokens(
-        lexer,
         "1.    [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM",
         ["LINELABEL"] + ['ID'] * 6
     )
 
 
-def test_lemmatize(lexer):
+def test_lemmatize():
     compare_tokens(
-        lexer,
         "#lem: šatti[year]N; n; Ṭebetu[1]MN; " +
         "mūša[at night]AV; ūm[day]N; n",
         ["LEM"] + ['ID', 'SEMICOLON'] * 5 + ['ID']
     )
 
 
-def test_loose_dollar(lexer):
+def test_loose_dollar():
     compare_tokens(
-        lexer,
         "$ (a loose dollar line)",
         ["DOLLAR", "PARENTHETICALID"],
         [None, "(a loose dollar line)"]
     )
 
 
-def test_loose_nested_dollar(lexer):
+def test_loose_nested_dollar():
     compare_tokens(
-        lexer,
         "$ (a (very) loose dollar line)",
         ["DOLLAR", "PARENTHETICALID"],
         [None, "(a (very) loose dollar line)"]
     )
 
 
-def test_loose_end_nested_dollar(lexer):
+def test_loose_end_nested_dollar():
     compare_tokens(
-        lexer,
         "$ (a loose dollar line (wow))",
         ["DOLLAR", "PARENTHETICALID"],
         [None, "(a loose dollar line (wow))"]
     )
 
 
-def test_strict_dollar(lexer):
+def test_strict_dollar():
     compare_tokens(
-        lexer,
         "$ reverse blank",
         ["DOLLAR", "REFERENCE", "BLANK"]
     )
 
 
-def test_translation_intro(lexer):
+def test_translation_intro():
     compare_tokens(
-        lexer,
         "@translation parallel en project",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT"]
     )
 
 
-def test_translation_text(lexer):
+def test_translation_text():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "1.    Year 63, Ṭebetu (Month X), night of day 2:^1^",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE",
@@ -311,9 +281,8 @@ def test_translation_text(lexer):
     )
 
 
-def test_translation_multiline_text(lexer):
+def test_translation_multiline_text():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "1.    Year 63, Ṭebetu (Month X)\n" +
         " , night of day 2\n",
@@ -324,9 +293,8 @@ def test_translation_multiline_text(lexer):
     )
 
 
-def test_translation_labeled_text(lexer):
+def test_translation_labeled_text():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 4\n" +
         "Then it will be taken for the rites and rituals.\n\n",
@@ -339,9 +307,8 @@ def test_translation_labeled_text(lexer):
     )
 
 
-def test_translation_labeled_noted_text(lexer):
+def test_translation_labeled_noted_text():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label r 8\n" +
         "The priest says the gods have performed these actions. ^1^\n\n" +
@@ -360,9 +327,8 @@ def test_translation_labeled_noted_text(lexer):
     )
 
 
-def test_translation_labeled_dashlabel(lexer):
+def test_translation_labeled_dashlabel():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 14-15 - o 20\n" +
         "You strew all (kinds of) seed.\n\n",
@@ -374,9 +340,8 @@ def test_translation_labeled_dashlabel(lexer):
     )
 
 
-def test_translation_labeled_atlabel(lexer):
+def test_translation_labeled_atlabel():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@(o 20) You strew all (kinds of) seed.\n" +
         "@(o i 2) No-one will occupy the king of Akkad's throne.\n\n",
@@ -390,9 +355,8 @@ def test_translation_labeled_atlabel(lexer):
     )
 
 
-def test_translation_range_label_prime(lexer):
+def test_translation_range_label_prime():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label r 1' - r 2'\n",
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -402,9 +366,8 @@ def test_translation_range_label_prime(lexer):
     )
 
 
-def test_translation_label_unicode_suffix(lexer):
+def test_translation_label_unicode_suffix():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         u'@label r A\u2081\n',
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -414,9 +377,8 @@ def test_translation_label_unicode_suffix(lexer):
     )
 
 
-def test_translation_label_unicode_prime(lexer):
+def test_translation_label_unicode_prime():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         u'@label r 1\u2019\n',
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -426,9 +388,8 @@ def test_translation_label_unicode_prime(lexer):
     )
 
 
-def test_translation_label_unicode_prime2(lexer):
+def test_translation_label_unicode_prime2():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         u'@label r 1\xb4\n',
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -438,9 +399,8 @@ def test_translation_label_unicode_prime2(lexer):
     )
 
 
-def test_translation_label_unicode_prime3(lexer):
+def test_translation_label_unicode_prime3():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         u'@label r 1\u2032\n',
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -450,9 +410,8 @@ def test_translation_label_unicode_prime3(lexer):
     )
 
 
-def test_translation_label_unicode_prime4(lexer):
+def test_translation_label_unicode_prime4():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         u'@label r 1\u02CA\n',
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -462,9 +421,8 @@ def test_translation_label_unicode_prime4(lexer):
     )
 
 
-def test_translation_range_label_plus(lexer):
+def test_translation_range_label_plus():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label+ o 28\n",
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -472,10 +430,9 @@ def test_translation_range_label_plus(lexer):
     )
 
 
-def test_translation_label_long_reference(lexer):
+def test_translation_label_long_reference():
     "Translations can have full surface names rather than single letter"
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label obverse 28\n",
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -483,9 +440,8 @@ def test_translation_label_long_reference(lexer):
     )
 
 
-def test_translation_symbols_in_translation(lexer):
+def test_translation_symbols_in_translation():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 1'\n" +
         "[...] ... (zodiacal sign) 8, 10° = (sign) 12, 10°\n\n",
@@ -495,9 +451,8 @@ def test_translation_symbols_in_translation(lexer):
     )
 
 
-def test_translation_ats_in_translation(lexer):
+def test_translation_ats_in_translation():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 1'\n" +
         "@kupputu (means): affliction (@? and) reduction?@;" +
@@ -508,12 +463,11 @@ def test_translation_ats_in_translation(lexer):
     )
 
 
-def test_translation_blank_line_begins_translation(lexer):
+def test_translation_blank_line_begins_translation():
     # A double newline normally ends a translation paragraph
     # But this is NOT the case at the beginning of a section,
     # Apparently.
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 16\n" +
         "\n" +
@@ -525,12 +479,11 @@ def test_translation_blank_line_begins_translation(lexer):
     )
 
 
-def test_translation_blank_line_amid_translation(lexer):
+def test_translation_blank_line_amid_translation():
     # A double newline normally ends a translation paragraph
     # But this is NOT the case at the beginning of a section,
     # Apparently.
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@(4) their [cri]mes [have been forgiven] by the king." +
         " (As to) all [the\n" +
@@ -546,12 +499,11 @@ def test_translation_blank_line_amid_translation(lexer):
     )
 
 
-def test_translation_no_blank_line_in_labeled_translation(lexer):
+def test_translation_no_blank_line_in_labeled_translation():
     # This functionality is expressly forbidden at
     # http://build.oracc.org/doc2/help/editinginatf/translations/index.html
     # But appears is in cm_31_139 anyway
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 13\n" +
         "@al-@ŋa₂-@ŋa₂ @al-@ŋa₂-@ŋa₂ @šag₄-@ba-@ni" +
@@ -568,11 +520,10 @@ def test_translation_no_blank_line_in_labeled_translation(lexer):
     )
 
 
-def test_translation_ATlines_in_translation(lexer):
+def test_translation_ATlines_in_translation():
     # @ within Translations mark Foreign
     # http://oracc.museum.upenn.edu/doc/help/editinginatf/translations/index.html
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@obverse\n" +
         "1'. @MUD (means) trembling. @MUD (means) dark.",
@@ -581,9 +532,8 @@ def test_translation_ATlines_in_translation(lexer):
     )
 
 
-def test_translation_range_label_periods(lexer):
+def test_translation_range_label_periods():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label t.e. 1\n",
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -592,9 +542,8 @@ def test_translation_range_label_periods(lexer):
          None, "t.e.", "1"])
 
 
-def test_interlinear_translation(lexer):
+def test_interlinear_translation():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "1'. ⸢x⸣\n" +
         "#tr: English\n",
@@ -603,9 +552,8 @@ def test_interlinear_translation(lexer):
          "TR", "ID", "NEWLINE"])
 
 
-def test_multilineinterlinear_translation(lexer):
+def test_multilineinterlinear_translation():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "1'. ⸢x⸣\n" +
         "#tr: English\n" +
@@ -615,54 +563,48 @@ def test_multilineinterlinear_translation(lexer):
          "TR", "ID", "NEWLINE"])
 
 
-def test_note_internalflag(lexer):
+def test_note_internalflag():
     compare_tokens(
-        lexer,
         "@note Hello James's World",
         ["NOTE", "ID"],
         [None, "Hello James's World"]
     )
 
 
-def test_note_internalspace(lexer):
+def test_note_internalspace():
     compare_tokens(
-        lexer,
         "@note Hello James",
         ["NOTE", "ID"],
         [None, "Hello James"]
     )
 
 
-def test_note_onechar(lexer):
+def test_note_onechar():
     compare_tokens(
-        lexer,
         "@note H",
         ["NOTE", "ID"],
         [None, "H"]
     )
 
 
-def test_note_short(lexer):
+def test_note_short():
     compare_tokens(
-        lexer,
         "@note I'm",
         ["NOTE", "ID"],
         [None, "I'm"]
     )
 
 
-def test_division_note(lexer):
+def test_division_note():
     compare_tokens(
-        lexer,
         "@note ^1^ A note to the translation.\n",
         ["NOTE", "HAT", "ID", "HAT", "ID", "NEWLINE"],
         [None, None, "1", None, "A note to the translation.", None]
     )
 
 
-def test_hash_note(lexer):
+def test_hash_note():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n" +
         "3.    U₄!-BI? 20* [(ina)] 9.30 ina(DIŠ) MAŠ₂!(BAR)\n" +
@@ -672,11 +614,10 @@ def test_hash_note(lexer):
     )
 
 
-def test_hash_note_UPPERCASE(lexer):
+def test_hash_note_UPPERCASE():
     # Some files in the corpus such as ctn_4_168.atf
     # Contains #NOTE: even if the line should be #note:
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n" +
         "3.    U₄!-BI? 20* [(ina)] 9.30 ina(DIŠ) MAŠ₂!(BAR)\n" +
@@ -686,11 +627,10 @@ def test_hash_note_UPPERCASE(lexer):
     )
 
 
-def test_hash_note_multiline(lexer):
+def test_hash_note_multiline():
     # Notes can be free text until a double-newline.
     line = "a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
     compare_tokens(
-        lexer,
         "1. " + line + "\n" +
         "#note: Does this combine with the next line?\n"
         "It should.\n\n",
@@ -701,10 +641,9 @@ def test_hash_note_multiline(lexer):
     )
 
 
-def test_open_text_with_dots(lexer):
+def test_open_text_with_dots():
     # This must not come out as a linelabel of Hello.
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@label o 1\nHello. World\n\n",
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
@@ -713,48 +652,42 @@ def test_open_text_with_dots(lexer):
     )
 
 
-def test_flagged_object(lexer):
+def test_flagged_object():
     compare_tokens(
-        lexer,
         "@object which is remarkable and broken!#\n",
         ["OBJECT", "ID", "EXCLAIM", "HASH", "NEWLINE"])
 
 
-def test_comment(lexer):
+def test_comment():
     compare_tokens(
-        lexer,
         "# I've added various things for test purposes\n",
         ['COMMENT', "ID", "NEWLINE"]
     )
 
 
-def test_nospace_comment(lexer):
+def test_nospace_comment():
     compare_tokens(
-        lexer,
         "#I've added various things for test purposes\n",
         ['COMMENT', "ID", "NEWLINE"]
     )
 
 
-def test_check_comment(lexer):
+def test_check_comment():
     compare_tokens(
-        lexer,
         "#CHECK: I've added various things for test purposes\n",
         ['CHECK', "ID", "NEWLINE"]
     )
 
 
-def test_dotline(lexer):
+def test_dotline():
     compare_tokens(
-        lexer,
         ". \n",
         ['NEWLINE']
     )
 
 
-def test_translation_heading(lexer):
+def test_translation_heading():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "@h1 A translation heading\n",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
@@ -762,9 +695,8 @@ def test_translation_heading(lexer):
     )
 
 
-def test_heading(lexer):
+def test_heading():
     compare_tokens(
-        lexer,
         "@obverse\n" +
         "@h1 A heading\n",
         ["OBVERSE", "NEWLINE"] +
@@ -772,45 +704,40 @@ def test_heading(lexer):
     )
 
 
-def test_double_comment(lexer):
+def test_double_comment():
     """Not sure if this is correct; but can't find
     anything in structure or lemmatization doc"""
     compare_tokens(
-        lexer,
         "## papān libbi[belly] (already in gloss, same spelling)\n",
         ['COMMENT', 'ID', 'NEWLINE']
     )
 
 
-def test_ruling(lexer):
+def test_ruling():
     compare_tokens(
-        lexer,
         "$ single ruling",
         ["DOLLAR", "SINGLE", "RULING"]
     )
 
 
-def test_described_object(lexer):
+def test_described_object():
     compare_tokens(
-        lexer,
         "@object An object that fits no other category\n",
         ["OBJECT", "ID", "NEWLINE"],
         [None, "An object that fits no other category"]
     )
 
 
-def test_nested_object(lexer):
+def test_nested_object():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n",
         ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE"]
     )
 
 
-def test_object_line(lexer):
+def test_object_line():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n" +
         "1.    [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM\n"
@@ -823,17 +750,15 @@ def test_object_line(lexer):
     )
 
 
-def test_dot_in_linelabel(lexer):
+def test_dot_in_linelabel():
     compare_tokens(
-        lexer,
         "1.1.    [MU]\n",
         ['LINELABEL', 'ID', 'NEWLINE']
     )
 
 
-def test_score_lines(lexer):
+def test_score_lines():
     compare_tokens(
-        lexer,
         "@score matrix parsed\n" +
         "1.4′. %n ḫašḫūr [api] lal[laga imḫur-līm?]\n" +
         "#lem: ḫašḫūr[apple (tree)]N; api[reed-bed]N\n\n" +
@@ -853,9 +778,8 @@ def test_score_lines(lexer):
     )
 
 
-def test_composite(lexer):
+def test_composite():
     compare_tokens(
-        lexer,
         "&Q002769 = SB Anzu 1\n" +
         "@composite\n" +
         "#project: cams/gkab\n" +
@@ -873,9 +797,8 @@ def test_composite(lexer):
     )
 
 
-def test_translated_composite(lexer):
+def test_translated_composite():
     compare_tokens(
-        lexer,
         "&Q002769 = SB Anzu 1\n" +
         "@composite\n" +
         "#project: cams/gkab\n" +
@@ -897,9 +820,8 @@ def test_translated_composite(lexer):
     )
 
 
-def test_equalbrace(lexer):
+def test_equalbrace():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@reverse\n" +
         "2'.    ITI# an-ni-u2#\n" +
@@ -911,9 +833,8 @@ def test_equalbrace(lexer):
     )
 
 
-def test_multilingual_interlinear(lexer):
+def test_multilingual_interlinear():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n" +
         "1. dim₃#-me-er# [...]\n" +
@@ -933,9 +854,8 @@ def test_multilingual_interlinear(lexer):
     )
 
 
-def test_strict_in_parallel(lexer):
+def test_strict_in_parallel():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "$ reverse blank",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
@@ -943,11 +863,10 @@ def test_strict_in_parallel(lexer):
     )
 
 
-def test_query_in_parallel(lexer):
+def test_query_in_parallel():
     """"The parallel ID regex was to general and identified ? after
         @obverse as an ID token not a QUERY"""
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "@obverse?",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
@@ -955,9 +874,8 @@ def test_query_in_parallel(lexer):
     )
 
 
-def test_loose_in_labeled(lexer):
+def test_loose_in_labeled():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "$ (Break)\n" +
         "@(r 2) I am\n\n",
@@ -967,9 +885,8 @@ def test_loose_in_labeled(lexer):
     )
 
 
-def test_ati_in_translation(lexer):
+def test_ati_in_translation():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@(r 2) I am\n" +
         "@i{eššēšu-}festival\n",
@@ -978,11 +895,10 @@ def test_ati_in_translation(lexer):
     )
 
 
-def test_blank_after_para_transctrl_windows(lexer):
+def test_blank_after_para_transctrl_windows():
     """[...] should not exit the para state but did previously
        due to a not as stric regex """
     compare_tokens(
-        lexer,
         "@translation labeled en project\r\n" +
         "@(o i 1')\r\n" +
         "[...]\r\n\r\n" +
@@ -997,11 +913,10 @@ def test_blank_after_para_transctrl_windows(lexer):
     )
 
 
-def test_blank_after_para_transctrl(lexer):
+def test_blank_after_para_transctrl():
     """[...] should not exit the para state but did previously
        due to a not as stric regex """
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "@(o i 1)\n" +
         "[(If) in] Tašritu (month VII), on day 1, " +
@@ -1016,9 +931,8 @@ def test_blank_after_para_transctrl(lexer):
     )
 
 
-def test_strict_in_labelled_parallel(lexer):
+def test_strict_in_labelled_parallel():
     compare_tokens(
-        lexer,
         "@translation labeled en project\n" +
         "$ reverse blank",
         ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
@@ -1026,9 +940,8 @@ def test_strict_in_labelled_parallel(lexer):
     )
 
 
-def test_strict_as_loose_in_translation(lexer):
+def test_strict_as_loose_in_translation():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "$ Continued in text no. 2\n",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
@@ -1036,9 +949,8 @@ def test_strict_as_loose_in_translation(lexer):
     )
 
 
-def test_punctuated_translation(lexer):
+def test_punctuated_translation():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "1. 'What is going on?', said the King!\n",
         ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
@@ -1048,9 +960,8 @@ def test_punctuated_translation(lexer):
     )
 
 
-def test_translation_note(lexer):
+def test_translation_note():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "@reverse\n" +
         "#note: reverse uninscribed\n",
@@ -1060,9 +971,8 @@ def test_translation_note(lexer):
     )
 
 
-def test_equals_in_translation_note(lexer):
+def test_equals_in_translation_note():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "@reverse\n" +
         '#note: The CAD translation šarriru = "humble",\n',
@@ -1072,9 +982,8 @@ def test_equals_in_translation_note(lexer):
         )
 
 
-def test_note_ended_by_strucuture(lexer):
+def test_note_ended_by_strucuture():
     compare_tokens(
-        lexer,
         "@translation parallel en project\n" +
         "@obverse\n" +
         '#note: The CAD translation šarriru = "humble",\n' +
@@ -1094,7 +1003,7 @@ def test_note_ended_by_strucuture(lexer):
     u"5\u02CA",
     u"6\xb4"
 ])
-def test_note_ended_by_line(lexer, line_label):
+def test_note_ended_by_line(line_label):
     'Notes can be free text until the next line label.'
     # Sample text.
     line1 = u"a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
@@ -1107,7 +1016,6 @@ def test_note_ended_by_line(lexer, line_label):
     else:
         label2 = str(next_label) + label1[1:]
     compare_tokens(
-        lexer,
         label1 + ". " + line1 + "\n" +
         "#note: Does this combine with the next line?\n" +
         label2 + ". " + line2 + "\n",
@@ -1120,9 +1028,8 @@ def test_note_ended_by_line(lexer, line_label):
     )
 
 
-def test_milestone(lexer):
+def test_milestone():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n" +
         "@m=locator catchline\n" +
@@ -1134,9 +1041,8 @@ def test_milestone(lexer):
     )
 
 
-def test_include(lexer):
+def test_include():
     compare_tokens(
-        lexer,
         "@tablet\n" +
         "@obverse\n" +
         "@include dcclt:P229061 = MSL 07, 197 V02, 210 V11\n",
@@ -1146,9 +1052,8 @@ def test_include(lexer):
     )
 
 
-def test_double_newline_and_lexpos(lexer):
+def test_double_newline_and_lexpos():
     compare_tokens(
-        lexer,
         "@obverse\n" +
         "\n" +
         "#note:\n",
@@ -1158,9 +1063,8 @@ def test_double_newline_and_lexpos(lexer):
         [1, 8, 11, 16])
 
 
-def test_blankline_with_tab_inadsorb(lexer):
+def test_blankline_with_tab_inadsorb():
     compare_tokens(
-        lexer,
         "# ES mu-lu = lu₂, ša₃-ab = šag\n" +
         "	\n" +
         "7. keš₂-da",
@@ -1168,19 +1072,19 @@ def test_blankline_with_tab_inadsorb(lexer):
         ["#", "ES mu-lu = lu₂, ša₃-ab = šag", "\n\t\n", '7', "keš₂-da"])
 
 
-def test_invalid_at_raises_syntax_error(lexer):
+def test_invalid_at_raises_syntax_error():
     string = u"@obversel\n"
-    ensure_raises_and_not(lexer, string, nwarnings=1)
+    ensure_raises_and_not(string, nwarnings=1)
 
 
-def test_invalid_hash_raises_syntax_error(lexer):
+def test_invalid_hash_raises_syntax_error():
     string = u"#lems: Ṣalbatanu[Mars]CN\n"
-    ensure_raises_and_not(lexer, string, nwarnings=2)
+    ensure_raises_and_not(string, nwarnings=2)
 
 
-def test_invalid_id_syntax_error(lexer):
+def test_invalid_id_syntax_error():
     string = u"Ṣalbatanu[Mars]CN\n"
-    ensure_raises_and_not(lexer, string, nwarnings=1)
+    ensure_raises_and_not(string, nwarnings=1)
 
 
 def test_resolve_keyword_no_extra():

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -21,7 +21,6 @@ along with PyORACC. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 from itertools import repeat
-from unittest import TestCase
 import pytest
 from pyoracc.atf.common.atflex import AtfLexer
 from pyoracc import _pyversion
@@ -31,975 +30,1166 @@ else:
     from itertools import zip_longest
 
 
-class TestLexer(TestCase):
-    """A class that contains all tests of the ATFLexer"""
-    def setUp(self):
-        self.lexer = AtfLexer().lexer
-
-    def compare_tokens(self, content, expected_types, expected_values=None,
-                       expected_lineno=None, expected_lexpos=None):
-        self.lexer.input(content)
-        if expected_values is None:
-            expected_values = repeat(None)
-        if expected_lineno is None:
-            expected_lineno = repeat(None)
-        if expected_lexpos is None:
-            expected_lexpos = repeat(None)
-        for e_type, e_value, e_lineno, e_lexpos, token in zip_longest(
-                expected_types,
-                expected_values,
-                expected_lineno,
-                expected_lexpos,
-                self.lexer):
-            if token is None and e_type is None:
-                break
-            assert token.type == e_type
-            if e_value:
-                assert token.value == e_value
-            if e_lineno:
-                assert token.lineno == e_lineno
-            if e_lexpos:
-                assert token.lexpos == e_lexpos
-
-    def ensure_raises_and_not(self, string, nwarnings):
-        self.lexer.input(string)
-        with pytest.raises(SyntaxError) as excinfo:
-            for i in self.lexer:
-                pass
-        # If we allow invalid syntax this should not raise
-        self.lexer = AtfLexer(skipinvalid=True).lexer
-        self.lexer.input(string)
-        with pytest.warns(UserWarning) as record:
-            for i in self.lexer:
-                pass
-        assert len(record) == nwarnings
-
-    def test_code(self):
-        self.compare_tokens(
-            "&X001001 = JCS 48, 089\n",
-            ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"],
-            [None, "X001001", None, "JCS 48, 089"]
-        )
-
-    def test_crlf(self):
-        self.compare_tokens(
-            "&X001001 = JCS 48, 089\r\n" +
-            "#project: cams/gkab\n\r",
-            ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
-            ["PROJECT", "ID", "NEWLINE"]
-        )
-
-    def test_project(self):
-        self.compare_tokens(
-            "#project: cams/gkab\n",
-            ["PROJECT", "ID", "NEWLINE"],
-            [None, "cams/gkab", None]
-        )
-
-    def test_key(self):
-        self.compare_tokens(
-            "#key: cdli=ND 02688\n",
-            ["KEY", "ID", "EQUALS", "ID", "NEWLINE"],
-            [None, "cdli", None, "ND 02688", None]
-        )
-
-    def test_language_protocol(self):
-        self.compare_tokens(
-            "#atf: lang akk-x-stdbab\n",
-            ["ATF", "LANG", "ID", "NEWLINE"],
-            [None, None, "akk-x-stdbab"]
-        )
-
-    def test_use_unicode(self):
-        self.compare_tokens(
-            "#atf: use unicode\n",
-            ["ATF", "USE", "UNICODE", "NEWLINE"]
-        )
-
-    def test_use_math(self):
-        self.compare_tokens(
-            "#atf: use math\n",
-            ["ATF", "USE", "MATH", "NEWLINE"]
-        )
-
-    def test_use_legacy(self):
-        self.compare_tokens(
-            "#atf: use legacy\n",
-            ["ATF", "USE", "LEGACY", "NEWLINE"]
-        )
-
-    def test_bib(self):
-        self.compare_tokens(
-            "#bib:  MEE 15 54\n",
-            ["BIB", "ID", "NEWLINE"]
-        )
-
-    def test_bib_long(self):
-        # not documented but common
-        self.compare_tokens(
-            "#bib:  MEE 4 73 = EV a\n",
-            ["BIB", "ID", "EQUALS", "ID", "NEWLINE"]
-        )
-
-    def test_link(self):
-        self.compare_tokens(
-            "#link: def A = P363716 = TCL 06, 44\n" +
-            "@tablet\n",
-            ["LINK", "DEF", "ID", "EQUALS", "ID", "EQUALS", "ID", "NEWLINE",
-             "TABLET", "NEWLINE"],
-            [None, None, "A", None, "P363716", None, "TCL 06, 44"]
-        )
-
-    def test_link_parallel_slash(self):
-        self.compare_tokens(
-            "#link: parallel dcclt/obale:P274929 = IM 070209\n" +
-            "@tablet\n",
-            ["LINK", "PARALLEL", "ID", "EQUALS", "ID", "NEWLINE",
-             "TABLET", "NEWLINE"],
-            [None, None, "dcclt/obale:P274929", None, "IM 070209"]
-        )
-
-    def test_link_parallel(self):
-        self.compare_tokens(
-            "#link: parallel abcd:P363716 = TCL 06, 44\n" +
-            "@tablet\n",
-            ["LINK", "PARALLEL", "ID", "EQUALS", "ID", "NEWLINE",
-             "TABLET", "NEWLINE"],
-            [None, None, "abcd:P363716", None, "TCL 06, 44"]
-        )
-
-    def test_link_reference(self):
-        self.compare_tokens(
-            "|| A o ii 10\n",
-            ["PARBAR", "ID", "ID", "ID", "ID", "NEWLINE"]
-        )
-
-    def test_link_reference_range(self):
-        self.compare_tokens(
-            "|| A o ii 10 -  o ii 12 \n",
-            ["PARBAR", "ID", "ID", "ID", "ID", "MINUS",
-             "ID", "ID", "ID", "NEWLINE"]
-        )
-
-    def test_link_reference_prime_range(self):
-        self.compare_tokens(
-            "|| A o ii 10' -  o ii' 12 \n",
-            ["PARBAR", "ID", "ID", "ID", "ID", "MINUS",
-             "ID", "ID", "ID", "NEWLINE"]
-        )
-
-    def test_score(self):
-        self.compare_tokens(
-            "@score matrix parsed word\n",
-            ["SCORE", "ID", "ID", "ID", "NEWLINE"]
-        )
-
-    def test_division_tablet(self):
-        self.compare_tokens(
-            "@tablet",
-            ["TABLET"]
-        )
-
-    def test_text_linenumber(self):
-        self.compare_tokens(
-            "1.    [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM",
-            ["LINELABEL"] + ['ID'] * 6
-        )
-
-    def test_lemmatize(self):
-        self.compare_tokens(
-            "#lem: šatti[year]N; n; Ṭebetu[1]MN; " +
-            "mūša[at night]AV; ūm[day]N; n",
-            ["LEM"] + ['ID', 'SEMICOLON'] * 5 + ['ID']
-        )
-
-    def test_loose_dollar(self):
-        self.compare_tokens(
-            "$ (a loose dollar line)",
-            ["DOLLAR", "PARENTHETICALID"],
-            [None, "(a loose dollar line)"]
-        )
-
-    def test_loose_nested_dollar(self):
-        self.compare_tokens(
-            "$ (a (very) loose dollar line)",
-            ["DOLLAR", "PARENTHETICALID"],
-            [None, "(a (very) loose dollar line)"]
-        )
-
-    def test_loose_end_nested_dollar(self):
-        self.compare_tokens(
-            "$ (a loose dollar line (wow))",
-            ["DOLLAR", "PARENTHETICALID"],
-            [None, "(a loose dollar line (wow))"]
-        )
-
-    def test_strict_dollar(self):
-        self.compare_tokens(
-            "$ reverse blank",
-            ["DOLLAR", "REFERENCE", "BLANK"]
-        )
-
-    def test_translation_intro(self):
-        self.compare_tokens(
-            "@translation parallel en project",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT"]
-        )
-
-    def test_translation_text(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "1.    Year 63, Ṭebetu (Month X), night of day 2:^1^",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE",
-             "LINELABEL", "ID", "HAT", "ID", "HAT"],
-            [None, "parallel", "en", "project", None,
-             "1", "Year 63, Ṭebetu (Month X), night of day 2:",
-             None, '1', None]
-        )
-
-    def test_translation_multiline_text(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "1.    Year 63, Ṭebetu (Month X)\n" +
-            " , night of day 2\n",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE",
-             "LINELABEL", "ID", "NEWLINE"],
-            [None, "parallel", "en", "project", None,
-             "1", "Year 63, Ṭebetu (Month X) , night of day 2", None]
-        )
-
-    def test_translation_labeled_text(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 4\n" +
-            "Then it will be taken for the rites and rituals.\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "o", "4", None,
-             'Then it will be taken for the rites and rituals.', None]
-        )
-
-    def test_translation_labeled_noted_text(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label r 8\n" +
-            "The priest says the gods have performed these actions. ^1^\n\n" +
-            "@note ^1^ Parenthesised text follows Neo-Assyrian source\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "HAT", "ID", "HAT", "NEWLINE",
-             "NOTE", "HAT", "ID", "HAT", "ID", 'NEWLINE'],
-            [None, "labeled", "en", "project", None,
-             None, "r", "8", None,
-             'The priest says the gods have performed these actions.',
-             None, "1", None, None,
-             None, None, "1", None,
-             "Parenthesised text follows Neo-Assyrian source"]
-
-        )
-
-    def test_translation_labeled_dashlabel(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 14-15 - o 20\n" +
-            "You strew all (kinds of) seed.\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "MINUS", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "o", "14-15", None, "o", "20", None]
-        )
-
-    def test_translation_labeled_atlabel(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@(o 20) You strew all (kinds of) seed.\n" +
-            "@(o i 2) No-one will occupy the king of Akkad's throne.\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "OPENR", "ID", "ID", "CLOSER", "ID", "NEWLINE",
-             "OPENR", "ID", "ID", "ID", "CLOSER", "ID", "NEWLINE", ],
-            [None, "labeled", "en", "project", None,
-             None, "o", "20", None, "You strew all (kinds of) seed.", None,
-             None, "o", "i", "2", None,
-             "No-one will occupy the king of Akkad's throne.", None, ]
-        )
-
-    def test_translation_range_label_prime(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label r 1' - r 2'\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "MINUS", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "r", "1'", None, "r", "2'", None]
-        )
-
-    def test_translation_label_unicode_suffix(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            u'@label r A\u2081\n',
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "r", u"A\u2081"]
-        )
-
-    def test_translation_label_unicode_prime(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            u'@label r 1\u2019\n',
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "r", "1'", None]
-        )
-
-    def test_translation_label_unicode_prime2(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            u'@label r 1\xb4\n',
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "r", "1'", None]
-        )
-
-    def test_translation_label_unicode_prime3(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            u'@label r 1\u2032\n',
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "r", "1'", None]
-        )
-
-    def test_translation_label_unicode_prime4(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            u'@label r 1\u02CA\n',
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "r", "1'", None]
-        )
-
-    def test_translation_range_label_plus(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label+ o 28\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"]
-        )
-
-    def test_translation_label_long_reference(self):
-        "Translations can have full surface names rather than single letter"
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label obverse 28\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "REFERENCE", "ID", "NEWLINE"]
-        )
-
-    def test_translation_symbols_in_translation(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 1'\n" +
-            "[...] ... (zodiacal sign) 8, 10° = (sign) 12, 10°\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"]
-        )
-
-    def test_translation_ats_in_translation(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 1'\n" +
-            "@kupputu (means): affliction (@? and) reduction?@;" +
-            " they are ... like cisterns.\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"]
-        )
-
-    def test_translation_blank_line_begins_translation(self):
-        # A double newline normally ends a translation paragraph
-        # But this is NOT the case at the beginning of a section,
-        # Apparently.
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 16\n" +
-            "\n" +
-            "@šipir @ṭuhdu @DU means: a message of abundance" +
-            " will come triumphantly.\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"]
-        )
-
-    def test_translation_blank_line_amid_translation(self):
-        # A double newline normally ends a translation paragraph
-        # But this is NOT the case at the beginning of a section,
-        # Apparently.
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@(4) their [cri]mes [have been forgiven] by the king." +
-            " (As to) all [the\n" +
-            "\n" +
-            "    libe]ls that [have been uttered against me " +
-            "in the palace, which] he has\n" +
-            "\n" +
-            "    heard, [I am not guilty of] any [of them! " +
-            "N]ow, should there be a\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "OPENR", "ID", "CLOSER", "ID", "NEWLINE",
-             "ID", "NEWLINE", "ID", "NEWLINE"]
-        )
-
-    def test_translation_no_blank_line_in_labeled_translation(self):
-        # This functionality is expressly forbidden at
-        # http://build.oracc.org/doc2/help/editinginatf/translations/index.html
-        # But appears is in cm_31_139 anyway
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 13\n" +
-            "@al-@ŋa₂-@ŋa₂ @al-@ŋa₂-@ŋa₂ @šag₄-@ba-@ni" +
-            " @nu-@sed-@da (means) he will" +
-            "remove (... and) he will place (...); his heart will not rest" +
-            "It is said in the textual corpus of the lamentation-priests.\n" +
-            "@label o 15\n" +
-            "Text\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"]
-        )
-
-    def test_translation_ATlines_in_translation(self):
-        # @ within Translations mark Foreign
-        # http://oracc.museum.upenn.edu/doc/help/editinginatf/translations/index.html
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@obverse\n" +
-            "1'. @MUD (means) trembling. @MUD (means) dark.",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "OBVERSE", "NEWLINE", "ID"]
-        )
-
-    def test_translation_range_label_periods(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label t.e. 1\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE"],
-            [None, "labeled", "en", "project", None,
-             None, "t.e.", "1"])
-
-    def test_interlinear_translation(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "1'. ⸢x⸣\n" +
-            "#tr: English\n",
-            ["TABLET", "NEWLINE",
-             "LINELABEL", "ID", "NEWLINE",
-             "TR", "ID", "NEWLINE"])
-
-    def test_multilineinterlinear_translation(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "1'. ⸢x⸣\n" +
-            "#tr: English\n" +
-            " on multiple lines\n",
-            ["TABLET", "NEWLINE",
-             "LINELABEL", "ID", "NEWLINE",
-             "TR", "ID", "NEWLINE"])
-
-    def test_note_internalflag(self):
-        self.compare_tokens(
-            "@note Hello James's World",
-            ["NOTE", "ID"],
-            [None, "Hello James's World"]
-        )
-
-    def test_note_internalspace(self):
-        self.compare_tokens(
-            "@note Hello James",
-            ["NOTE", "ID"],
-            [None, "Hello James"]
-        )
-
-    def test_note_onechar(self):
-        self.compare_tokens(
-            "@note H",
-            ["NOTE", "ID"],
-            [None, "H"]
-        )
-
-    def test_note_short(self):
-        self.compare_tokens(
-            "@note I'm",
-            ["NOTE", "ID"],
-            [None, "I'm"]
-        )
-
-    def test_division_note(self):
-        self.compare_tokens(
-            "@note ^1^ A note to the translation.\n",
-            ["NOTE", "HAT", "ID", "HAT", "ID", "NEWLINE"],
-            [None, None, "1", None, "A note to the translation.", None]
-        )
-
-    def test_hash_note(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n" +
-            "3.    U₄!-BI? 20* [(ina)] 9.30 ina(DIŠ) MAŠ₂!(BAR)\n" +
-            "#note: Note to line.\n",
-            ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE",
-             "LINELABEL"] + ["ID"] * 6 + ["NEWLINE", "NOTE", "ID", "NEWLINE"]
-        )
-
-    def test_hash_note_UPPERCASE(self):
-        # Some files in the corpus such as ctn_4_168.atf
-        # Contains #NOTE: even if the line should be #note:
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n" +
-            "3.    U₄!-BI? 20* [(ina)] 9.30 ina(DIŠ) MAŠ₂!(BAR)\n" +
-            "#NOTE: Note to line.\n",
-            ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE",
-             "LINELABEL"] + ["ID"] * 6 + ["NEWLINE", "NOTE", "ID", "NEWLINE"]
-        )
-
-    def test_hash_note_multiline(self):
-        # Notes can be free text until a double-newline.
-        line = "a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
-        self.compare_tokens(
-            "1. " + line + "\n" +
-            "#note: Does this combine with the next line?\n"
-            "It should.\n\n",
-            ["LINELABEL"] + ["ID"] * len(line.split()) + ["NEWLINE"] +
-            ["NOTE", "ID", "NEWLINE"],
-            ['1'] + line.split() +
-            [None, None, "Does this combine with the next line?\nIt should."]
-        )
-
-    def test_open_text_with_dots(self):
-        # This must not come out as a linelabel of Hello.
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@label o 1\nHello. World\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
-             "LABEL", "ID", "ID", "NEWLINE",
-             "ID", "NEWLINE"]
-        )
-
-    def test_flagged_object(self):
-        self.compare_tokens("@object which is remarkable and broken!#\n",
-                            ["OBJECT", "ID", "EXCLAIM", "HASH", "NEWLINE"])
-
-    def test_comment(self):
-        self.compare_tokens(
-            "# I've added various things for test purposes\n",
-            ['COMMENT', "ID", "NEWLINE"]
-        )
-
-    def test_nospace_comment(self):
-        self.compare_tokens(
-            "#I've added various things for test purposes\n",
-            ['COMMENT', "ID", "NEWLINE"]
-        )
-
-    def test_check_comment(self):
-        self.compare_tokens(
-            "#CHECK: I've added various things for test purposes\n",
-            ['CHECK', "ID", "NEWLINE"]
-        )
-
-    def test_dotline(self):
-        self.compare_tokens(
-            ". \n",
-            ['NEWLINE']
-        )
-
-    def test_translation_heading(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "@h1 A translation heading\n",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["HEADING", "ID", "NEWLINE"]
-        )
-
-    def test_heading(self):
-        self.compare_tokens(
-            "@obverse\n" +
-            "@h1 A heading\n",
-            ["OBVERSE", "NEWLINE"] +
-            ["HEADING", "ID", "NEWLINE"]
-        )
-
-    def test_double_comment(self):
-        """Not sure if this is correct; but can't find
-        anything in structure or lemmatization doc"""
-        self.compare_tokens(
-            "## papān libbi[belly] (already in gloss, same spelling)\n",
-            ['COMMENT', 'ID', 'NEWLINE']
-        )
-
-    def test_ruling(self):
-        self.compare_tokens(
-            "$ single ruling",
-            ["DOLLAR", "SINGLE", "RULING"]
-        )
-
-    def test_described_object(self):
-        self.compare_tokens(
-            "@object An object that fits no other category\n",
-            ["OBJECT", "ID", "NEWLINE"],
-            [None, "An object that fits no other category"]
-        )
-
-    def test_nested_object(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n",
-            ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE"]
-        )
-
-    def test_object_line(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n" +
-            "1.    [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM\n"
-            "#lem: šatti[year]N; n; Ṭebetu[1]MN; mūša[at night]AV; " +
-            "ūm[day]N; n\n",
-            ['TABLET', 'NEWLINE',
-             "OBVERSE", 'NEWLINE',
-             'LINELABEL'] + ['ID'] * 6 + ['NEWLINE', 'LEM'] +
-            ['ID', 'SEMICOLON'] * 5 + ['ID', "NEWLINE"]
-        )
-
-    def test_dot_in_linelabel(self):
-        self.compare_tokens(
-            "1.1.    [MU]\n",
-            ['LINELABEL', 'ID', 'NEWLINE']
-        )
-
-    def test_score_lines(self):
-        self.compare_tokens(
-            "@score matrix parsed\n" +
-            "1.4′. %n ḫašḫūr [api] lal[laga imḫur-līm?]\n" +
-            "#lem: ḫašḫūr[apple (tree)]N; api[reed-bed]N\n\n" +
-            "A₁_obv_i_4′: [x x x x x] {ú}la-al-[la-ga? {ú}im-ḫu-ur-lim?]\n" +
-            "#lem: u; u; u; u; u; " +
-            "+lalangu[(a leguminous vegetable)]N$lallaga\n\n" +
-            "e_obv_15′–16′: {giš}ḪAŠḪUR [GIŠ.GI] — // [{ú}IGI-lim]\n" +
-            "#lem: +hašhūru[apple (tree)]N$hašhūr; api[reed-bed]N;" +
-            " imhur-līm['heals-a-thousand'-plant]N\n\n",
-            ['SCORE', 'ID', 'ID', "NEWLINE"] +
-            ['LINELABEL'] + ['ID'] * 5 + ['NEWLINE'] +
-            ['LEM', 'ID', 'SEMICOLON', 'ID', 'NEWLINE'] +
-            ['SCORELABEL'] + ['ID'] * 7 + ['NEWLINE'] +
-            ['LEM'] + ['ID', 'SEMICOLON'] * 5 + ['ID', 'NEWLINE'] +
-            ['SCORELABEL'] + ['ID'] * 5 + ['NEWLINE'] +
-            ['LEM'] + ['ID', 'SEMICOLON'] * 2 + ['ID', 'NEWLINE']
-        )
-
-    def test_composite(self):
-        self.compare_tokens(
-            "&Q002769 = SB Anzu 1\n" +
-            "@composite\n" +
-            "#project: cams/gkab\n" +
-            "1.   bi#-in šar da-ad-mi šu-pa-a na-ram {d}ma#-mi\n" +
-            "&Q002770 = SB Anzu 2\n" +
-            "#project: cams/gkab\n" +
-            "1.   bi-riq ur-ha šuk-na a-dan-na\n",
-            ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
-            ['COMPOSITE', 'NEWLINE'] +
-            ["PROJECT", "ID", "NEWLINE"] +
-            ["LINELABEL"] + ['ID'] * 6 + ['NEWLINE'] +
-            ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
-            ["PROJECT", "ID", "NEWLINE"] +
-            ["LINELABEL"] + ['ID'] * 4 + ["NEWLINE"]
-        )
-
-    def test_translated_composite(self):
-        self.compare_tokens(
-            "&Q002769 = SB Anzu 1\n" +
-            "@composite\n" +
-            "#project: cams/gkab\n" +
-            "1.   bi#-in šar da-ad-mi šu-pa-a na-ram {d}ma#-mi\n" +
-            "@translation labeled en project\n" +
-            "@(1) English\n"
-            "&Q002770 = SB Anzu 2\n" +
-            "#project: cams/gkab\n" +
-            "1.   bi-riq ur-ha šuk-na a-dan-na\n",
-            ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
-            ['COMPOSITE', 'NEWLINE'] +
-            ["PROJECT", "ID", "NEWLINE"] +
-            ["LINELABEL"] + ['ID'] * 6 + ['NEWLINE'] +
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
-            ["OPENR", "ID", "CLOSER", "ID", "NEWLINE"] +
-            ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
-            ["PROJECT", "ID", "NEWLINE"] +
-            ["LINELABEL"] + ['ID'] * 4 + ["NEWLINE"]
-        )
-
-    def test_equalbrace(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@reverse\n" +
-            "2'.    ITI# an-ni-u2#\n" +
-            "={    ur-hu\n",
-            ['TABLET', "NEWLINE"] +
-            ["REVERSE", "NEWLINE"] +
-            ["LINELABEL"] + ['ID'] * 2 + ["NEWLINE"] +
-            ["EQUALBRACE", "ID", "NEWLINE"]
-        )
-
-    def test_multilingual_interlinear(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n" +
-            "1. dim₃#-me-er# [...]\n" +
-            "#lem: diŋir[deity]N; u\n" +
-            "== %sb DINGIR-MEŠ GAL#-MEŠ# [...]\n" +
-            "#lem: ilū[god]N; rabûtu[great]AJ; u\n" +
-            "# ES dim₃-me-er = diŋir\n" +
-            "|| A o ii 15\n",
-            ['TABLET', "NEWLINE"] +
-            ["OBVERSE", "NEWLINE"] +
-            ["LINELABEL"] + ['ID'] * 2 + ["NEWLINE"] +
-            ["LEM"] + ["ID", "SEMICOLON"] + ["ID"] + ["NEWLINE"] +
-            ["MULTILINGUAL", "ID"] + ["ID"] * 3 + ["NEWLINE"] +
-            ["LEM"] + ["ID", "SEMICOLON"] * 2 + ["ID"] + ["NEWLINE"] +
-            ["COMMENT", "ID", "NEWLINE"] +
-            ["PARBAR", "ID", "ID", "ID", "ID", "NEWLINE"]
-        )
-
-    def test_strict_in_parallel(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "$ reverse blank",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["DOLLAR", "ID"]
-        )
-
-    def test_query_in_parallel(self):
-        """"The parallel ID regex was to general and identified ? after
-            @obverse as an ID token not a QUERY"""
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "@obverse?",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["OBVERSE", "QUERY"]
-        )
-
-    def test_loose_in_labeled(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "$ (Break)\n" +
-            "@(r 2) I am\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
-            ["DOLLAR", "ID", "NEWLINE"] +
-            ["OPENR", "ID", "ID", "CLOSER", "ID", "NEWLINE"]
-        )
-
-    def test_ati_in_translation(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@(r 2) I am\n" +
-            "@i{eššēšu-}festival\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
-            ["OPENR", "ID", "ID", "CLOSER", "ID", "NEWLINE"]
-        )
-
-    def test_blank_after_para_transctrl_windows(self):
-        """[...] should not exit the para state but did previously
-           due to a not as stric regex """
-        self.compare_tokens(
-            "@translation labeled en project\r\n" +
-            "@(o i 1')\r\n" +
-            "[...]\r\n\r\n" +
-            "@(o i 2')\r\n" +
-            "[... you put] inside [his] ears [and the evil] " +
-            "afflicting his head [will be eradicated].\r\n\r\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
-            ["OPENR", "ID", "ID", "ID", "CLOSER"] +
-            ["ID", "NEWLINE"] +
-            ["OPENR", "ID", "ID", "ID", "CLOSER"] +
-            ["ID", "NEWLINE"]
-        )
-
-    def test_blank_after_para_transctrl(self):
-        """[...] should not exit the para state but did previously
-           due to a not as stric regex """
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "@(o i 1)\n" +
-            "[(If) in] Tašritu (month VII), on day 1, " +
-            "a solar eclipse takes place: [...].\n\n" +
-            "@(o i 2)\n" +
-            "[...], on day 7, a solar eclipse takes place: [...].\n\n",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
-            ["OPENR", "ID", "ID", "ID", "CLOSER"] +
-            ["ID", "NEWLINE"] +
-            ["OPENR", "ID", "ID", "ID", "CLOSER"] +
-            ["ID", "NEWLINE"]
-        )
-
-    def test_strict_in_labelled_parallel(self):
-        self.compare_tokens(
-            "@translation labeled en project\n" +
-            "$ reverse blank",
-            ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
-            ["DOLLAR", "ID"]
-        )
-
-    def test_strict_as_loose_in_translation(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "$ Continued in text no. 2\n",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["DOLLAR", "ID", "NEWLINE"]
-        )
-
-    def test_punctuated_translation(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "1. 'What is going on?', said the King!\n",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["LINELABEL", "ID", "NEWLINE"],
-            [None, None, "en", None, None] +
-            ["1", "'What is going on?', said the King!", None]
-        )
-
-    def test_translation_note(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "@reverse\n" +
-            "#note: reverse uninscribed\n",
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["REVERSE", "NEWLINE"] +
-            ["NOTE", "ID", "NEWLINE"]
-        )
-
-    def test_equals_in_translation_note(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "@reverse\n" +
-            '#note: The CAD translation šarriru = "humble",\n',
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["REVERSE", "NEWLINE"] +
-            ["NOTE", "ID", "NEWLINE"]
-            )
-
-    def test_note_ended_by_strucuture(self):
-        self.compare_tokens(
-            "@translation parallel en project\n" +
-            "@obverse\n" +
-            '#note: The CAD translation šarriru = "humble",\n' +
-            '@reverse',
-            ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
-            ["OBVERSE", "NEWLINE"] +
-            ["NOTE", "ID", "NEWLINE"] +
-            ["REVERSE"]
-        )
-
-    def compare_note_ended_by_line(self, line_label):
-        'Helper for Note para state termination.'
-        # Sample text.
-        line1 = u"a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
-        line2 = u"a-kal-ši-na ṭi-id-di"
-        # Generate the successive line numbers in the same style.
-        label1 = line_label
-        next_label = int(label1[:1]) + 1
-        if _pyversion() == 2:
-            label2 = unicode(next_label) + label1[1:]
-        else:
-            label2 = str(next_label) + label1[1:]
-        self.compare_tokens(
-            label1 + ". " + line1 + "\n" +
-            "#note: Does this combine with the next line?\n" +
-            label2 + ". " + line2 + "\n",
-            ["LINELABEL"] + ["ID"] * len(line1.split()) + ["NEWLINE"] +
-            ["NOTE", "ID", "NEWLINE"] +
-            ["LINELABEL"] + ["ID"] * len(line2.split()) + ["NEWLINE"],
-            [label1] + line1.split() +
-            [None, None, "Does this combine with the next line?", None] +
-            [label2] + line2.split() + [None]
-        )
-
-    def test_note_ended_by_line(self):
-        'Notes can be free text until the next line label.'
-        for label in ["1",
-                      "2'",
-                      u"3\u2019",
-                      u"4\u2032",
-                      u"5\u02CA",
-                      u"6\xb4"]:
-            self.compare_note_ended_by_line(label)
-
-    def test_milestone(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n" +
-            "@m=locator catchline\n" +
-            "16'. si-i-ia-a-a-ku\n",
-            ["TABLET", "NEWLINE",
-             "OBVERSE", "NEWLINE",
-             "M", "EQUALS", "ID", "NEWLINE",
-             "LINELABEL", "ID", "NEWLINE"]
-        )
-
-    def test_include(self):
-        self.compare_tokens(
-            "@tablet\n" +
-            "@obverse\n" +
-            "@include dcclt:P229061 = MSL 07, 197 V02, 210 V11\n",
-            ["TABLET", "NEWLINE",
-             "OBVERSE", "NEWLINE",
-             "INCLUDE", "ID", 'EQUALS', 'ID', "NEWLINE"]
-        )
-
-    def test_double_newline_and_lexpos(self):
-        self.compare_tokens(
-            "@obverse\n" +
-            "\n" +
-            "#note:\n",
-            ["OBVERSE", "NEWLINE", "NOTE", "NEWLINE"],
-            ["obverse", "\n\n", "note", "\n"],
-            [1, 1, 3, 3],
-            [1, 8, 11, 16])
-
-    def test_blankline_with_tab_inadsorb(self):
-        self.compare_tokens(
-            "# ES mu-lu = lu₂, ša₃-ab = šag\n" +
-            "	\n" +
-            "7. keš₂-da",
-            ["COMMENT", "ID", "NEWLINE", "LINELABEL", "ID"],
-            ["#", "ES mu-lu = lu₂, ša₃-ab = šag", "\n\t\n", '7', "keš₂-da"])
-
-    def test_invalid_at_raises_syntax_error(self):
-        string = u"@obversel\n"
-        self.ensure_raises_and_not(string, nwarnings=1)
-
-    def test_invalid_hash_raises_syntax_error(self):
-        string = u"#lems: Ṣalbatanu[Mars]CN\n"
-        self.ensure_raises_and_not(string, nwarnings=2)
-
-    def test_invalid_id_syntax_error(self):
-        string = u"Ṣalbatanu[Mars]CN\n"
-        self.ensure_raises_and_not(string, nwarnings=1)
-
-    @staticmethod
-    def test_resolve_keyword_no_extra():
-        '''Test that resolve_keyword works correcty when extra is not passes
-        This never happes in actual code. Hench this test'''
-        mylexer = AtfLexer()
-        result = mylexer.resolve_keyword('obverse',
-                                         mylexer.structures)
-        assert result == 'OBVERSE'
+@pytest.fixture
+def lexer():
+    """AtfLexer instance used by each test."""
+    return AtfLexer().lexer
+
+
+def compare_tokens(lexer, content, expected_types, expected_values=None,
+                   expected_lineno=None, expected_lexpos=None):
+    lexer.input(content)
+    if expected_values is None:
+        expected_values = repeat(None)
+    if expected_lineno is None:
+        expected_lineno = repeat(None)
+    if expected_lexpos is None:
+        expected_lexpos = repeat(None)
+    for e_type, e_value, e_lineno, e_lexpos, token in zip_longest(
+            expected_types,
+            expected_values,
+            expected_lineno,
+            expected_lexpos,
+            lexer):
+        if token is None and e_type is None:
+            break
+        assert token.type == e_type
+        if e_value:
+            assert token.value == e_value
+        if e_lineno:
+            assert token.lineno == e_lineno
+        if e_lexpos:
+            assert token.lexpos == e_lexpos
+
+
+def ensure_raises_and_not(lexer, string, nwarnings):
+    lexer.input(string)
+    with pytest.raises(SyntaxError) as excinfo:
+        for i in lexer:
+            pass
+    # If we allow invalid syntax this should not raise
+    lexer = AtfLexer(skipinvalid=True).lexer
+    lexer.input(string)
+    with pytest.warns(UserWarning) as record:
+        for i in lexer:
+            pass
+    assert len(record) == nwarnings
+
+
+def test_code(lexer):
+    compare_tokens(
+        lexer,
+        "&X001001 = JCS 48, 089\n",
+        ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"],
+        [None, "X001001", None, "JCS 48, 089"]
+    )
+
+
+def test_crlf(lexer):
+    compare_tokens(
+        lexer,
+        "&X001001 = JCS 48, 089\r\n" +
+        "#project: cams/gkab\n\r",
+        ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
+        ["PROJECT", "ID", "NEWLINE"]
+    )
+
+
+def test_project(lexer):
+    compare_tokens(
+        lexer,
+        "#project: cams/gkab\n",
+        ["PROJECT", "ID", "NEWLINE"],
+        [None, "cams/gkab", None]
+    )
+
+
+def test_key(lexer):
+    compare_tokens(
+        lexer,
+        "#key: cdli=ND 02688\n",
+        ["KEY", "ID", "EQUALS", "ID", "NEWLINE"],
+        [None, "cdli", None, "ND 02688", None]
+    )
+
+
+def test_language_protocol(lexer):
+    compare_tokens(
+        lexer,
+        "#atf: lang akk-x-stdbab\n",
+        ["ATF", "LANG", "ID", "NEWLINE"],
+        [None, None, "akk-x-stdbab"]
+    )
+
+
+def test_use_unicode(lexer):
+    compare_tokens(
+        lexer,
+        "#atf: use unicode\n",
+        ["ATF", "USE", "UNICODE", "NEWLINE"]
+    )
+
+
+def test_use_math(lexer):
+    compare_tokens(
+        lexer,
+        "#atf: use math\n",
+        ["ATF", "USE", "MATH", "NEWLINE"]
+    )
+
+
+def test_use_legacy(lexer):
+    compare_tokens(
+        lexer,
+        "#atf: use legacy\n",
+        ["ATF", "USE", "LEGACY", "NEWLINE"]
+    )
+
+
+def test_bib(lexer):
+    compare_tokens(
+        lexer,
+        "#bib:  MEE 15 54\n",
+        ["BIB", "ID", "NEWLINE"]
+    )
+
+
+def test_bib_long(lexer):
+    # not documented but common
+    compare_tokens(
+        lexer,
+        "#bib:  MEE 4 73 = EV a\n",
+        ["BIB", "ID", "EQUALS", "ID", "NEWLINE"]
+    )
+
+
+def test_link(lexer):
+    compare_tokens(
+        lexer,
+        "#link: def A = P363716 = TCL 06, 44\n" +
+        "@tablet\n",
+        ["LINK", "DEF", "ID", "EQUALS", "ID", "EQUALS", "ID", "NEWLINE",
+         "TABLET", "NEWLINE"],
+        [None, None, "A", None, "P363716", None, "TCL 06, 44"]
+    )
+
+
+def test_link_parallel_slash(lexer):
+    compare_tokens(
+        lexer,
+        "#link: parallel dcclt/obale:P274929 = IM 070209\n" +
+        "@tablet\n",
+        ["LINK", "PARALLEL", "ID", "EQUALS", "ID", "NEWLINE",
+         "TABLET", "NEWLINE"],
+        [None, None, "dcclt/obale:P274929", None, "IM 070209"]
+    )
+
+
+def test_link_parallel(lexer):
+    compare_tokens(
+        lexer,
+        "#link: parallel abcd:P363716 = TCL 06, 44\n" +
+        "@tablet\n",
+        ["LINK", "PARALLEL", "ID", "EQUALS", "ID", "NEWLINE",
+         "TABLET", "NEWLINE"],
+        [None, None, "abcd:P363716", None, "TCL 06, 44"]
+    )
+
+
+def test_link_reference(lexer):
+    compare_tokens(
+        lexer,
+        "|| A o ii 10\n",
+        ["PARBAR", "ID", "ID", "ID", "ID", "NEWLINE"]
+    )
+
+
+def test_link_reference_range(lexer):
+    compare_tokens(
+        lexer,
+        "|| A o ii 10 -  o ii 12 \n",
+        ["PARBAR", "ID", "ID", "ID", "ID", "MINUS",
+         "ID", "ID", "ID", "NEWLINE"]
+    )
+
+
+def test_link_reference_prime_range(lexer):
+    compare_tokens(
+        lexer,
+        "|| A o ii 10' -  o ii' 12 \n",
+        ["PARBAR", "ID", "ID", "ID", "ID", "MINUS",
+         "ID", "ID", "ID", "NEWLINE"]
+    )
+
+
+def test_score(lexer):
+    compare_tokens(
+        lexer,
+        "@score matrix parsed word\n",
+        ["SCORE", "ID", "ID", "ID", "NEWLINE"]
+    )
+
+
+def test_division_tablet(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet",
+        ["TABLET"]
+    )
+
+
+def test_text_linenumber(lexer):
+    compare_tokens(
+        lexer,
+        "1.    [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM",
+        ["LINELABEL"] + ['ID'] * 6
+    )
+
+
+def test_lemmatize(lexer):
+    compare_tokens(
+        lexer,
+        "#lem: šatti[year]N; n; Ṭebetu[1]MN; " +
+        "mūša[at night]AV; ūm[day]N; n",
+        ["LEM"] + ['ID', 'SEMICOLON'] * 5 + ['ID']
+    )
+
+
+def test_loose_dollar(lexer):
+    compare_tokens(
+        lexer,
+        "$ (a loose dollar line)",
+        ["DOLLAR", "PARENTHETICALID"],
+        [None, "(a loose dollar line)"]
+    )
+
+
+def test_loose_nested_dollar(lexer):
+    compare_tokens(
+        lexer,
+        "$ (a (very) loose dollar line)",
+        ["DOLLAR", "PARENTHETICALID"],
+        [None, "(a (very) loose dollar line)"]
+    )
+
+
+def test_loose_end_nested_dollar(lexer):
+    compare_tokens(
+        lexer,
+        "$ (a loose dollar line (wow))",
+        ["DOLLAR", "PARENTHETICALID"],
+        [None, "(a loose dollar line (wow))"]
+    )
+
+
+def test_strict_dollar(lexer):
+    compare_tokens(
+        lexer,
+        "$ reverse blank",
+        ["DOLLAR", "REFERENCE", "BLANK"]
+    )
+
+
+def test_translation_intro(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT"]
+    )
+
+
+def test_translation_text(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "1.    Year 63, Ṭebetu (Month X), night of day 2:^1^",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE",
+         "LINELABEL", "ID", "HAT", "ID", "HAT"],
+        [None, "parallel", "en", "project", None,
+         "1", "Year 63, Ṭebetu (Month X), night of day 2:",
+         None, '1', None]
+    )
+
+
+def test_translation_multiline_text(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "1.    Year 63, Ṭebetu (Month X)\n" +
+        " , night of day 2\n",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE",
+         "LINELABEL", "ID", "NEWLINE"],
+        [None, "parallel", "en", "project", None,
+         "1", "Year 63, Ṭebetu (Month X) , night of day 2", None]
+    )
+
+
+def test_translation_labeled_text(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 4\n" +
+        "Then it will be taken for the rites and rituals.\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "o", "4", None,
+         'Then it will be taken for the rites and rituals.', None]
+    )
+
+
+def test_translation_labeled_noted_text(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label r 8\n" +
+        "The priest says the gods have performed these actions. ^1^\n\n" +
+        "@note ^1^ Parenthesised text follows Neo-Assyrian source\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "HAT", "ID", "HAT", "NEWLINE",
+         "NOTE", "HAT", "ID", "HAT", "ID", 'NEWLINE'],
+        [None, "labeled", "en", "project", None,
+         None, "r", "8", None,
+         'The priest says the gods have performed these actions.',
+         None, "1", None, None,
+         None, None, "1", None,
+         "Parenthesised text follows Neo-Assyrian source"]
+
+    )
+
+
+def test_translation_labeled_dashlabel(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 14-15 - o 20\n" +
+        "You strew all (kinds of) seed.\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "MINUS", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "o", "14-15", None, "o", "20", None]
+    )
+
+
+def test_translation_labeled_atlabel(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@(o 20) You strew all (kinds of) seed.\n" +
+        "@(o i 2) No-one will occupy the king of Akkad's throne.\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "OPENR", "ID", "ID", "CLOSER", "ID", "NEWLINE",
+         "OPENR", "ID", "ID", "ID", "CLOSER", "ID", "NEWLINE", ],
+        [None, "labeled", "en", "project", None,
+         None, "o", "20", None, "You strew all (kinds of) seed.", None,
+         None, "o", "i", "2", None,
+         "No-one will occupy the king of Akkad's throne.", None, ]
+    )
+
+
+def test_translation_range_label_prime(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label r 1' - r 2'\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "MINUS", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "r", "1'", None, "r", "2'", None]
+    )
+
+
+def test_translation_label_unicode_suffix(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        u'@label r A\u2081\n',
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "r", u"A\u2081"]
+    )
+
+
+def test_translation_label_unicode_prime(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        u'@label r 1\u2019\n',
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "r", "1'", None]
+    )
+
+
+def test_translation_label_unicode_prime2(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        u'@label r 1\xb4\n',
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "r", "1'", None]
+    )
+
+
+def test_translation_label_unicode_prime3(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        u'@label r 1\u2032\n',
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "r", "1'", None]
+    )
+
+
+def test_translation_label_unicode_prime4(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        u'@label r 1\u02CA\n',
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "r", "1'", None]
+    )
+
+
+def test_translation_range_label_plus(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label+ o 28\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"]
+    )
+
+
+def test_translation_label_long_reference(lexer):
+    "Translations can have full surface names rather than single letter"
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label obverse 28\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "REFERENCE", "ID", "NEWLINE"]
+    )
+
+
+def test_translation_symbols_in_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 1'\n" +
+        "[...] ... (zodiacal sign) 8, 10° = (sign) 12, 10°\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"]
+    )
+
+
+def test_translation_ats_in_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 1'\n" +
+        "@kupputu (means): affliction (@? and) reduction?@;" +
+        " they are ... like cisterns.\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"]
+    )
+
+
+def test_translation_blank_line_begins_translation(lexer):
+    # A double newline normally ends a translation paragraph
+    # But this is NOT the case at the beginning of a section,
+    # Apparently.
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 16\n" +
+        "\n" +
+        "@šipir @ṭuhdu @DU means: a message of abundance" +
+        " will come triumphantly.\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"]
+    )
+
+
+def test_translation_blank_line_amid_translation(lexer):
+    # A double newline normally ends a translation paragraph
+    # But this is NOT the case at the beginning of a section,
+    # Apparently.
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@(4) their [cri]mes [have been forgiven] by the king." +
+        " (As to) all [the\n" +
+        "\n" +
+        "    libe]ls that [have been uttered against me " +
+        "in the palace, which] he has\n" +
+        "\n" +
+        "    heard, [I am not guilty of] any [of them! " +
+        "N]ow, should there be a\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "OPENR", "ID", "CLOSER", "ID", "NEWLINE",
+         "ID", "NEWLINE", "ID", "NEWLINE"]
+    )
+
+
+def test_translation_no_blank_line_in_labeled_translation(lexer):
+    # This functionality is expressly forbidden at
+    # http://build.oracc.org/doc2/help/editinginatf/translations/index.html
+    # But appears is in cm_31_139 anyway
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 13\n" +
+        "@al-@ŋa₂-@ŋa₂ @al-@ŋa₂-@ŋa₂ @šag₄-@ba-@ni" +
+        " @nu-@sed-@da (means) he will" +
+        "remove (... and) he will place (...); his heart will not rest" +
+        "It is said in the textual corpus of the lamentation-priests.\n" +
+        "@label o 15\n" +
+        "Text\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"]
+    )
+
+
+def test_translation_ATlines_in_translation(lexer):
+    # @ within Translations mark Foreign
+    # http://oracc.museum.upenn.edu/doc/help/editinginatf/translations/index.html
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@obverse\n" +
+        "1'. @MUD (means) trembling. @MUD (means) dark.",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "OBVERSE", "NEWLINE", "ID"]
+    )
+
+
+def test_translation_range_label_periods(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label t.e. 1\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE"],
+        [None, "labeled", "en", "project", None,
+         None, "t.e.", "1"])
+
+
+def test_interlinear_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "1'. ⸢x⸣\n" +
+        "#tr: English\n",
+        ["TABLET", "NEWLINE",
+         "LINELABEL", "ID", "NEWLINE",
+         "TR", "ID", "NEWLINE"])
+
+
+def test_multilineinterlinear_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "1'. ⸢x⸣\n" +
+        "#tr: English\n" +
+        " on multiple lines\n",
+        ["TABLET", "NEWLINE",
+         "LINELABEL", "ID", "NEWLINE",
+         "TR", "ID", "NEWLINE"])
+
+
+def test_note_internalflag(lexer):
+    compare_tokens(
+        lexer,
+        "@note Hello James's World",
+        ["NOTE", "ID"],
+        [None, "Hello James's World"]
+    )
+
+
+def test_note_internalspace(lexer):
+    compare_tokens(
+        lexer,
+        "@note Hello James",
+        ["NOTE", "ID"],
+        [None, "Hello James"]
+    )
+
+
+def test_note_onechar(lexer):
+    compare_tokens(
+        lexer,
+        "@note H",
+        ["NOTE", "ID"],
+        [None, "H"]
+    )
+
+
+def test_note_short(lexer):
+    compare_tokens(
+        lexer,
+        "@note I'm",
+        ["NOTE", "ID"],
+        [None, "I'm"]
+    )
+
+
+def test_division_note(lexer):
+    compare_tokens(
+        lexer,
+        "@note ^1^ A note to the translation.\n",
+        ["NOTE", "HAT", "ID", "HAT", "ID", "NEWLINE"],
+        [None, None, "1", None, "A note to the translation.", None]
+    )
+
+
+def test_hash_note(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n" +
+        "3.    U₄!-BI? 20* [(ina)] 9.30 ina(DIŠ) MAŠ₂!(BAR)\n" +
+        "#note: Note to line.\n",
+        ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE",
+         "LINELABEL"] + ["ID"] * 6 + ["NEWLINE", "NOTE", "ID", "NEWLINE"]
+    )
+
+
+def test_hash_note_UPPERCASE(lexer):
+    # Some files in the corpus such as ctn_4_168.atf
+    # Contains #NOTE: even if the line should be #note:
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n" +
+        "3.    U₄!-BI? 20* [(ina)] 9.30 ina(DIŠ) MAŠ₂!(BAR)\n" +
+        "#NOTE: Note to line.\n",
+        ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE",
+         "LINELABEL"] + ["ID"] * 6 + ["NEWLINE", "NOTE", "ID", "NEWLINE"]
+    )
+
+
+def test_hash_note_multiline(lexer):
+    # Notes can be free text until a double-newline.
+    line = "a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
+    compare_tokens(
+        lexer,
+        "1. " + line + "\n" +
+        "#note: Does this combine with the next line?\n"
+        "It should.\n\n",
+        ["LINELABEL"] + ["ID"] * len(line.split()) + ["NEWLINE"] +
+        ["NOTE", "ID", "NEWLINE"],
+        ['1'] + line.split() +
+        [None, None, "Does this combine with the next line?\nIt should."]
+    )
+
+
+def test_open_text_with_dots(lexer):
+    # This must not come out as a linelabel of Hello.
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@label o 1\nHello. World\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE",
+         "LABEL", "ID", "ID", "NEWLINE",
+         "ID", "NEWLINE"]
+    )
+
+
+def test_flagged_object(lexer):
+    compare_tokens(
+        lexer,
+        "@object which is remarkable and broken!#\n",
+        ["OBJECT", "ID", "EXCLAIM", "HASH", "NEWLINE"])
+
+
+def test_comment(lexer):
+    compare_tokens(
+        lexer,
+        "# I've added various things for test purposes\n",
+        ['COMMENT', "ID", "NEWLINE"]
+    )
+
+
+def test_nospace_comment(lexer):
+    compare_tokens(
+        lexer,
+        "#I've added various things for test purposes\n",
+        ['COMMENT', "ID", "NEWLINE"]
+    )
+
+
+def test_check_comment(lexer):
+    compare_tokens(
+        lexer,
+        "#CHECK: I've added various things for test purposes\n",
+        ['CHECK', "ID", "NEWLINE"]
+    )
+
+
+def test_dotline(lexer):
+    compare_tokens(
+        lexer,
+        ". \n",
+        ['NEWLINE']
+    )
+
+
+def test_translation_heading(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "@h1 A translation heading\n",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["HEADING", "ID", "NEWLINE"]
+    )
+
+
+def test_heading(lexer):
+    compare_tokens(
+        lexer,
+        "@obverse\n" +
+        "@h1 A heading\n",
+        ["OBVERSE", "NEWLINE"] +
+        ["HEADING", "ID", "NEWLINE"]
+    )
+
+
+def test_double_comment(lexer):
+    """Not sure if this is correct; but can't find
+    anything in structure or lemmatization doc"""
+    compare_tokens(
+        lexer,
+        "## papān libbi[belly] (already in gloss, same spelling)\n",
+        ['COMMENT', 'ID', 'NEWLINE']
+    )
+
+
+def test_ruling(lexer):
+    compare_tokens(
+        lexer,
+        "$ single ruling",
+        ["DOLLAR", "SINGLE", "RULING"]
+    )
+
+
+def test_described_object(lexer):
+    compare_tokens(
+        lexer,
+        "@object An object that fits no other category\n",
+        ["OBJECT", "ID", "NEWLINE"],
+        [None, "An object that fits no other category"]
+    )
+
+
+def test_nested_object(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n",
+        ["TABLET", "NEWLINE", "OBVERSE", "NEWLINE"]
+    )
+
+
+def test_object_line(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n" +
+        "1.    [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM\n"
+        "#lem: šatti[year]N; n; Ṭebetu[1]MN; mūša[at night]AV; " +
+        "ūm[day]N; n\n",
+        ['TABLET', 'NEWLINE',
+         "OBVERSE", 'NEWLINE',
+         'LINELABEL'] + ['ID'] * 6 + ['NEWLINE', 'LEM'] +
+        ['ID', 'SEMICOLON'] * 5 + ['ID', "NEWLINE"]
+    )
+
+
+def test_dot_in_linelabel(lexer):
+    compare_tokens(
+        lexer,
+        "1.1.    [MU]\n",
+        ['LINELABEL', 'ID', 'NEWLINE']
+    )
+
+
+def test_score_lines(lexer):
+    compare_tokens(
+        lexer,
+        "@score matrix parsed\n" +
+        "1.4′. %n ḫašḫūr [api] lal[laga imḫur-līm?]\n" +
+        "#lem: ḫašḫūr[apple (tree)]N; api[reed-bed]N\n\n" +
+        "A₁_obv_i_4′: [x x x x x] {ú}la-al-[la-ga? {ú}im-ḫu-ur-lim?]\n" +
+        "#lem: u; u; u; u; u; " +
+        "+lalangu[(a leguminous vegetable)]N$lallaga\n\n" +
+        "e_obv_15′–16′: {giš}ḪAŠḪUR [GIŠ.GI] — // [{ú}IGI-lim]\n" +
+        "#lem: +hašhūru[apple (tree)]N$hašhūr; api[reed-bed]N;" +
+        " imhur-līm['heals-a-thousand'-plant]N\n\n",
+        ['SCORE', 'ID', 'ID', "NEWLINE"] +
+        ['LINELABEL'] + ['ID'] * 5 + ['NEWLINE'] +
+        ['LEM', 'ID', 'SEMICOLON', 'ID', 'NEWLINE'] +
+        ['SCORELABEL'] + ['ID'] * 7 + ['NEWLINE'] +
+        ['LEM'] + ['ID', 'SEMICOLON'] * 5 + ['ID', 'NEWLINE'] +
+        ['SCORELABEL'] + ['ID'] * 5 + ['NEWLINE'] +
+        ['LEM'] + ['ID', 'SEMICOLON'] * 2 + ['ID', 'NEWLINE']
+    )
+
+
+def test_composite(lexer):
+    compare_tokens(
+        lexer,
+        "&Q002769 = SB Anzu 1\n" +
+        "@composite\n" +
+        "#project: cams/gkab\n" +
+        "1.   bi#-in šar da-ad-mi šu-pa-a na-ram {d}ma#-mi\n" +
+        "&Q002770 = SB Anzu 2\n" +
+        "#project: cams/gkab\n" +
+        "1.   bi-riq ur-ha šuk-na a-dan-na\n",
+        ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
+        ['COMPOSITE', 'NEWLINE'] +
+        ["PROJECT", "ID", "NEWLINE"] +
+        ["LINELABEL"] + ['ID'] * 6 + ['NEWLINE'] +
+        ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
+        ["PROJECT", "ID", "NEWLINE"] +
+        ["LINELABEL"] + ['ID'] * 4 + ["NEWLINE"]
+    )
+
+
+def test_translated_composite(lexer):
+    compare_tokens(
+        lexer,
+        "&Q002769 = SB Anzu 1\n" +
+        "@composite\n" +
+        "#project: cams/gkab\n" +
+        "1.   bi#-in šar da-ad-mi šu-pa-a na-ram {d}ma#-mi\n" +
+        "@translation labeled en project\n" +
+        "@(1) English\n"
+        "&Q002770 = SB Anzu 2\n" +
+        "#project: cams/gkab\n" +
+        "1.   bi-riq ur-ha šuk-na a-dan-na\n",
+        ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
+        ['COMPOSITE', 'NEWLINE'] +
+        ["PROJECT", "ID", "NEWLINE"] +
+        ["LINELABEL"] + ['ID'] * 6 + ['NEWLINE'] +
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
+        ["OPENR", "ID", "CLOSER", "ID", "NEWLINE"] +
+        ["AMPERSAND", "ID", "EQUALS", "ID", "NEWLINE"] +
+        ["PROJECT", "ID", "NEWLINE"] +
+        ["LINELABEL"] + ['ID'] * 4 + ["NEWLINE"]
+    )
+
+
+def test_equalbrace(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@reverse\n" +
+        "2'.    ITI# an-ni-u2#\n" +
+        "={    ur-hu\n",
+        ['TABLET', "NEWLINE"] +
+        ["REVERSE", "NEWLINE"] +
+        ["LINELABEL"] + ['ID'] * 2 + ["NEWLINE"] +
+        ["EQUALBRACE", "ID", "NEWLINE"]
+    )
+
+
+def test_multilingual_interlinear(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n" +
+        "1. dim₃#-me-er# [...]\n" +
+        "#lem: diŋir[deity]N; u\n" +
+        "== %sb DINGIR-MEŠ GAL#-MEŠ# [...]\n" +
+        "#lem: ilū[god]N; rabûtu[great]AJ; u\n" +
+        "# ES dim₃-me-er = diŋir\n" +
+        "|| A o ii 15\n",
+        ['TABLET', "NEWLINE"] +
+        ["OBVERSE", "NEWLINE"] +
+        ["LINELABEL"] + ['ID'] * 2 + ["NEWLINE"] +
+        ["LEM"] + ["ID", "SEMICOLON"] + ["ID"] + ["NEWLINE"] +
+        ["MULTILINGUAL", "ID"] + ["ID"] * 3 + ["NEWLINE"] +
+        ["LEM"] + ["ID", "SEMICOLON"] * 2 + ["ID"] + ["NEWLINE"] +
+        ["COMMENT", "ID", "NEWLINE"] +
+        ["PARBAR", "ID", "ID", "ID", "ID", "NEWLINE"]
+    )
+
+
+def test_strict_in_parallel(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "$ reverse blank",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["DOLLAR", "ID"]
+    )
+
+
+def test_query_in_parallel(lexer):
+    """"The parallel ID regex was to general and identified ? after
+        @obverse as an ID token not a QUERY"""
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "@obverse?",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["OBVERSE", "QUERY"]
+    )
+
+
+def test_loose_in_labeled(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "$ (Break)\n" +
+        "@(r 2) I am\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
+        ["DOLLAR", "ID", "NEWLINE"] +
+        ["OPENR", "ID", "ID", "CLOSER", "ID", "NEWLINE"]
+    )
+
+
+def test_ati_in_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@(r 2) I am\n" +
+        "@i{eššēšu-}festival\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
+        ["OPENR", "ID", "ID", "CLOSER", "ID", "NEWLINE"]
+    )
+
+
+def test_blank_after_para_transctrl_windows(lexer):
+    """[...] should not exit the para state but did previously
+       due to a not as stric regex """
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\r\n" +
+        "@(o i 1')\r\n" +
+        "[...]\r\n\r\n" +
+        "@(o i 2')\r\n" +
+        "[... you put] inside [his] ears [and the evil] " +
+        "afflicting his head [will be eradicated].\r\n\r\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
+        ["OPENR", "ID", "ID", "ID", "CLOSER"] +
+        ["ID", "NEWLINE"] +
+        ["OPENR", "ID", "ID", "ID", "CLOSER"] +
+        ["ID", "NEWLINE"]
+    )
+
+
+def test_blank_after_para_transctrl(lexer):
+    """[...] should not exit the para state but did previously
+       due to a not as stric regex """
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "@(o i 1)\n" +
+        "[(If) in] Tašritu (month VII), on day 1, " +
+        "a solar eclipse takes place: [...].\n\n" +
+        "@(o i 2)\n" +
+        "[...], on day 7, a solar eclipse takes place: [...].\n\n",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
+        ["OPENR", "ID", "ID", "ID", "CLOSER"] +
+        ["ID", "NEWLINE"] +
+        ["OPENR", "ID", "ID", "ID", "CLOSER"] +
+        ["ID", "NEWLINE"]
+    )
+
+
+def test_strict_in_labelled_parallel(lexer):
+    compare_tokens(
+        lexer,
+        "@translation labeled en project\n" +
+        "$ reverse blank",
+        ["TRANSLATION", "LABELED", "ID", "PROJECT", "NEWLINE"] +
+        ["DOLLAR", "ID"]
+    )
+
+
+def test_strict_as_loose_in_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "$ Continued in text no. 2\n",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["DOLLAR", "ID", "NEWLINE"]
+    )
+
+
+def test_punctuated_translation(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "1. 'What is going on?', said the King!\n",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["LINELABEL", "ID", "NEWLINE"],
+        [None, None, "en", None, None] +
+        ["1", "'What is going on?', said the King!", None]
+    )
+
+
+def test_translation_note(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "@reverse\n" +
+        "#note: reverse uninscribed\n",
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["REVERSE", "NEWLINE"] +
+        ["NOTE", "ID", "NEWLINE"]
+    )
+
+
+def test_equals_in_translation_note(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "@reverse\n" +
+        '#note: The CAD translation šarriru = "humble",\n',
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["REVERSE", "NEWLINE"] +
+        ["NOTE", "ID", "NEWLINE"]
+        )
+
+
+def test_note_ended_by_strucuture(lexer):
+    compare_tokens(
+        lexer,
+        "@translation parallel en project\n" +
+        "@obverse\n" +
+        '#note: The CAD translation šarriru = "humble",\n' +
+        '@reverse',
+        ["TRANSLATION", "PARALLEL", "ID", "PROJECT", "NEWLINE"] +
+        ["OBVERSE", "NEWLINE"] +
+        ["NOTE", "ID", "NEWLINE"] +
+        ["REVERSE"]
+    )
+
+
+def compare_note_ended_by_line(lexer, line_label):
+    'Helper for Note para state termination.'
+    # Sample text.
+    line1 = u"a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
+    line2 = u"a-kal-ši-na ṭi-id-di"
+    # Generate the successive line numbers in the same style.
+    label1 = line_label
+    next_label = int(label1[:1]) + 1
+    if _pyversion() == 2:
+        label2 = unicode(next_label) + label1[1:]
+    else:
+        label2 = str(next_label) + label1[1:]
+    compare_tokens(
+        lexer,
+        label1 + ". " + line1 + "\n" +
+        "#note: Does this combine with the next line?\n" +
+        label2 + ". " + line2 + "\n",
+        ["LINELABEL"] + ["ID"] * len(line1.split()) + ["NEWLINE"] +
+        ["NOTE", "ID", "NEWLINE"] +
+        ["LINELABEL"] + ["ID"] * len(line2.split()) + ["NEWLINE"],
+        [label1] + line1.split() +
+        [None, None, "Does this combine with the next line?", None] +
+        [label2] + line2.split() + [None]
+    )
+
+
+def test_note_ended_by_line(lexer):
+    'Notes can be free text until the next line label.'
+    for label in ["1",
+                  "2'",
+                  u"3\u2019",
+                  u"4\u2032",
+                  u"5\u02CA",
+                  u"6\xb4"]:
+        compare_note_ended_by_line(lexer, label)
+
+
+def test_milestone(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n" +
+        "@m=locator catchline\n" +
+        "16'. si-i-ia-a-a-ku\n",
+        ["TABLET", "NEWLINE",
+         "OBVERSE", "NEWLINE",
+         "M", "EQUALS", "ID", "NEWLINE",
+         "LINELABEL", "ID", "NEWLINE"]
+    )
+
+
+def test_include(lexer):
+    compare_tokens(
+        lexer,
+        "@tablet\n" +
+        "@obverse\n" +
+        "@include dcclt:P229061 = MSL 07, 197 V02, 210 V11\n",
+        ["TABLET", "NEWLINE",
+         "OBVERSE", "NEWLINE",
+         "INCLUDE", "ID", 'EQUALS', 'ID', "NEWLINE"]
+    )
+
+
+def test_double_newline_and_lexpos(lexer):
+    compare_tokens(
+        lexer,
+        "@obverse\n" +
+        "\n" +
+        "#note:\n",
+        ["OBVERSE", "NEWLINE", "NOTE", "NEWLINE"],
+        ["obverse", "\n\n", "note", "\n"],
+        [1, 1, 3, 3],
+        [1, 8, 11, 16])
+
+
+def test_blankline_with_tab_inadsorb(lexer):
+    compare_tokens(
+        lexer,
+        "# ES mu-lu = lu₂, ša₃-ab = šag\n" +
+        "	\n" +
+        "7. keš₂-da",
+        ["COMMENT", "ID", "NEWLINE", "LINELABEL", "ID"],
+        ["#", "ES mu-lu = lu₂, ša₃-ab = šag", "\n\t\n", '7', "keš₂-da"])
+
+
+def test_invalid_at_raises_syntax_error(lexer):
+    string = u"@obversel\n"
+    ensure_raises_and_not(lexer, string, nwarnings=1)
+
+
+def test_invalid_hash_raises_syntax_error(lexer):
+    string = u"#lems: Ṣalbatanu[Mars]CN\n"
+    ensure_raises_and_not(lexer, string, nwarnings=2)
+
+
+def test_invalid_id_syntax_error(lexer):
+    string = u"Ṣalbatanu[Mars]CN\n"
+    ensure_raises_and_not(lexer, string, nwarnings=1)
+
+
+def test_resolve_keyword_no_extra():
+    '''Test that resolve_keyword works correcty when extra is not passes
+    This never happes in actual code. Hench this test'''
+    mylexer = AtfLexer()
+    result = mylexer.resolve_keyword('obverse',
+                                     mylexer.structures)
+    assert result == 'OBVERSE'

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -1086,8 +1086,16 @@ def test_note_ended_by_strucuture(lexer):
     )
 
 
-def compare_note_ended_by_line(lexer, line_label):
-    'Helper for Note para state termination.'
+@pytest.mark.parametrize('line_label', [
+    "1",
+    "2'",
+    u"3\u2019",
+    u"4\u2032",
+    u"5\u02CA",
+    u"6\xb4"
+])
+def test_note_ended_by_line(lexer, line_label):
+    'Notes can be free text until the next line label.'
     # Sample text.
     line1 = u"a-šar _saḫar.ḫi.a_ bu-bu-su-nu"
     line2 = u"a-kal-ši-na ṭi-id-di"
@@ -1110,17 +1118,6 @@ def compare_note_ended_by_line(lexer, line_label):
         [None, None, "Does this combine with the next line?", None] +
         [label2] + line2.split() + [None]
     )
-
-
-def test_note_ended_by_line(lexer):
-    'Notes can be free text until the next line label.'
-    for label in ["1",
-                  "2'",
-                  u"3\u2019",
-                  u"4\u2032",
-                  u"5\u02CA",
-                  u"6\xb4"]:
-        compare_note_ended_by_line(lexer, label)
 
 
 def test_milestone(lexer):

--- a/pyoracc/test/atf/test_atfserializer.py
+++ b/pyoracc/test/atf/test_atfserializer.py
@@ -31,134 +31,129 @@ from pyoracc.atf.common.atfyacc import AtfParser
 from pyoracc.model.line import Line
 
 
-class TestSerializer(TestCase):
-    """A class that contains all tests of the ATF Serializer"""
-    def setUp(self):
-        """
-        Initialize lexer and parser.
-        """
-        self.lexer = AtfLexer().lexer
-        self.parser = AtfParser().parser
+def parse(any_str):
+    """
+    Parse input string, could be just a line or a whole file content.
+    """
+    parsed = AtfFile(any_str)
+    return parsed
 
-    @staticmethod
-    def parse(any_str):
-        """
-        Parse input string, could be just a line or a whole file content.
-        """
-        parsed = AtfFile(any_str)
-        return parsed
 
-    @staticmethod
-    def serialize(any_object):
-        """
-        Serialize input object, from a simple lemma to a whole AtfFile object.
-        """
-        serialized = any_object.serialize()
-        return serialized
+def serialize(any_object):
+    """
+    Serialize input object, from a simple lemma to a whole AtfFile object.
+    """
+    serialized = any_object.serialize()
+    return serialized
 
-    def parse_then_serialize(self, any_str):
-        """
-        Shorthand for testing serialization.
-        """
-        return self.serialize(self.parse(any_str))
 
-    @staticmethod
-    def open_file(filename):
-        """
-        Open serialized file and output contents
-        """
-        return codecs.open(filename, "r", "utf-8").read()
+def parse_then_serialize(any_str):
+    """
+    Shorthand for testing serialization.
+    """
+    return serialize(parse(any_str))
 
-    @staticmethod
-    def save_file(content, filename):
-        """
-        Write serialized file on disk
-        """
-        serialized_file = codecs.open(filename, "w", "utf-8")
-        serialized_file.write(content)
-        serialized_file.close()
 
-    def test_belsunu_serializer(self):
-        """
-        Parse belsunu.atf, then serialize, parse again, serialize again,
-        compare.
-        Comparing serialized output with input file would bring up differences
-        that might not be significant (white spaces, newlines, etc).
-        The solution is to parse again the serialized file, serialize again,
-        then compare the two serializations.
-        """
-        serialized_1 = self.parse_then_serialize(belsunu())
-        self.save_file(serialized_1, output_filepath("belsunu.atf"))
-        serialized_2 = self.parse_then_serialize(serialized_1)
-        assert serialized_1 == serialized_2
+def open_file(filename):
+    """
+    Open serialized file and output contents
+    """
+    return codecs.open(filename, "r", "utf-8").read()
 
-    @pytest.mark.xfail
-    @staticmethod
-    def test_line_word():
-        """
-        Get a sample word with unicode chars and check serialization is
-        correct.
-        """
-        line = Line("1")
-        line.words.append(u"\u2086")
-        line_ser = line.serialize()
-        assert line_ser == "1.\t" + u"\u2086"
 
-    @staticmethod
-    def test_line_words():
-        """
-        Get a sample line of words with unicode chars and test serialization.
-        1. [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM
-        """
-        atf_file = AtfFile(belsunu())
-        uline = atf_file.text.children[0].children[0].children[0]
-        uwords = uline.words
-        gold = [u'[MU]', u'1.03-KAM', u'{iti}AB', u'GE\u2086', u'U\u2084',
-                u'2-KAM']
-        assert uwords == gold
+def save_file(content, filename):
+    """
+    Write serialized file on disk
+    """
+    serialized_file = codecs.open(filename, "w", "utf-8")
+    serialized_file.write(content)
+    serialized_file.close()
 
-    @staticmethod
-    def test_line_lemmas():
-        """
-        Get a sample line of lemmas with unicode chars and test serialization.
-        šatti[year]N; n; Ṭebetu[1]MN; mūša[at night]AV; ūm[day]N; n
-        """
-        atf_file = AtfFile(belsunu())
-        uline = atf_file.text.children[0].children[0].children[0]
-        ulemmas = uline.lemmas
-        gold = [u' \u0161atti[year]N', u'n', u'\u1e6cebetu[1]MN',
-                u'm\u016b\u0161a[at night]AV', u'\u016bm[day]N', u'n']
-        assert ulemmas == gold
+
+def test_belsunu_serializer():
+    """
+    Parse belsunu.atf, then serialize, parse again, serialize again,
+    compare.
+    Comparing serialized output with input file would bring up differences
+    that might not be significant (white spaces, newlines, etc).
+    The solution is to parse again the serialized file, serialize again,
+    then compare the two serializations.
+    """
+    serialized_1 = parse_then_serialize(belsunu())
+    save_file(serialized_1, output_filepath("belsunu.atf"))
+    serialized_2 = parse_then_serialize(serialized_1)
+    assert serialized_1 == serialized_2
+
+
+@pytest.mark.xfail
+def test_line_word():
+    """
+    Get a sample word with unicode chars and check serialization is
+    correct.
+    """
+    line = Line("1")
+    line.words.append(u"\u2086")
+    line_ser = line.serialize()
+    assert line_ser == "1.\t" + u"\u2086"
+
+
+def test_line_words():
+    """
+    Get a sample line of words with unicode chars and test serialization.
+    1. [MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM
+    """
+    atf_file = AtfFile(belsunu())
+    uline = atf_file.text.children[0].children[0].children[0]
+    uwords = uline.words
+    gold = [u'[MU]', u'1.03-KAM', u'{iti}AB', u'GE\u2086', u'U\u2084',
+            u'2-KAM']
+    assert uwords == gold
+
+
+def test_line_lemmas():
+    """
+    Get a sample line of lemmas with unicode chars and test serialization.
+    šatti[year]N; n; Ṭebetu[1]MN; mūša[at night]AV; ūm[day]N; n
+    """
+    atf_file = AtfFile(belsunu())
+    uline = atf_file.text.children[0].children[0].children[0]
+    ulemmas = uline.lemmas
+    gold = [u' \u0161atti[year]N', u'n', u'\u1e6cebetu[1]MN',
+            u'm\u016b\u0161a[at night]AV', u'\u016bm[day]N', u'n']
+    assert ulemmas == gold
 
 
 # TODO: Build list of atf files for testing and make a test to go through the
 # list of test and try serializing each of them.
-    @pytest.mark.xfail
-    def test_text_code_and_description(self):
-        """
-        Check if serializing works for the code/description case - first line
-        of ATF texts.
-        Note the parser always returns an AtfFile object, even when it's not
-        ATF-compliant.
-        """
-        atf = self.parse("&X001001 = JCS 48, 089\n")
-        serialized = self.serialize(atf)
-        assert serialized.strip()+"\n" == "&X001001 = JCS 48, 089\n"
+@pytest.mark.xfail
+def test_text_code_and_description():
+    """
+    Check if serializing works for the code/description case - first line
+    of ATF texts.
+    Note the parser always returns an AtfFile object, even when it's not
+    ATF-compliant.
+    """
+    atf = parse("&X001001 = JCS 48, 089\n")
+    serialized = serialize(atf)
+    assert serialized.strip()+"\n" == "&X001001 = JCS 48, 089\n"
 
-    @pytest.mark.xfail
-    def test_text_project(self):
-        """
-        Check if serializing works for the project lines.
-        Note the parser always returns an AtfFile object, even when it's not
-        ATF-compliant.
-        """
-        serialized = self.parse_then_serialize("#project: cams/gkab\n")
-        assert serialized.strip()+"\n" == "#project: cams/gkab\n"
 
-    @skip("test_text_language is not implemented yet")
-    def test_text_language(self):
-        pass
+@pytest.mark.xfail
+def test_text_project():
+    """
+    Check if serializing works for the project lines.
+    Note the parser always returns an AtfFile object, even when it's not
+    ATF-compliant.
+    """
+    serialized = parse_then_serialize("#project: cams/gkab\n")
+    assert serialized.strip()+"\n" == "#project: cams/gkab\n"
 
-    @skip("test_text_protocols is not implemented yet")
-    def test_text_protocols(self):
-        pass
+
+@pytest.mark.skip("test_text_language is not implemented yet")
+def test_text_language():
+    pass
+
+
+@pytest.mark.skip("test_text_protocols is not implemented yet")
+def test_text_protocols():
+    pass

--- a/pyoracc/test/atf/test_atfserializer.py
+++ b/pyoracc/test/atf/test_atfserializer.py
@@ -54,22 +54,6 @@ def parse_then_serialize(any_str):
     return serialize(parse(any_str))
 
 
-def open_file(filename):
-    """
-    Open serialized file and output contents
-    """
-    return codecs.open(filename, "r", "utf-8").read()
-
-
-def save_file(content, filename):
-    """
-    Write serialized file on disk
-    """
-    serialized_file = codecs.open(filename, "w", "utf-8")
-    serialized_file.write(content)
-    serialized_file.close()
-
-
 def test_belsunu_serializer():
     """
     Parse belsunu.atf, then serialize, parse again, serialize again,
@@ -80,7 +64,6 @@ def test_belsunu_serializer():
     then compare the two serializations.
     """
     serialized_1 = parse_then_serialize(belsunu())
-    save_file(serialized_1, output_filepath("belsunu.atf"))
     serialized_2 = parse_then_serialize(serialized_1)
     assert serialized_1 == serialized_2
 

--- a/pyoracc/test/atf/test_atfserializer.py
+++ b/pyoracc/test/atf/test_atfserializer.py
@@ -19,16 +19,11 @@ along with PyORACC. If not, see <http://www.gnu.org/licenses/>.
 '''
 
 
-import codecs
-from unittest import TestCase, skip
 import pytest
 
 from pyoracc.atf.common.atffile import AtfFile
-from pyoracc.test.fixtures import belsunu, output_filepath
-
-from pyoracc.atf.common.atflex import AtfLexer
-from pyoracc.atf.common.atfyacc import AtfParser
 from pyoracc.model.line import Line
+from pyoracc.test.fixtures import belsunu
 
 
 def parse(any_str):

--- a/pyoracc/test/atf/test_atfserializer.py
+++ b/pyoracc/test/atf/test_atfserializer.py
@@ -113,23 +113,21 @@ def test_text_code_and_description():
     """
     Check if serializing works for the code/description case - first line
     of ATF texts.
-    Note the parser always returns an AtfFile object, even when it's not
-    ATF-compliant.
     """
-    atf = parse("&X001001 = JCS 48, 089\n")
+    text = "&X001001 = JCS 48, 089\n"
+    atf = parse(text)
     serialized = serialize(atf)
-    assert serialized.strip()+"\n" == "&X001001 = JCS 48, 089\n"
+    assert serialized.strip()+"\n" == text
 
 
 @pytest.mark.xfail
 def test_text_project():
     """
     Check if serializing works for the project lines.
-    Note the parser always returns an AtfFile object, even when it's not
-    ATF-compliant.
     """
-    serialized = parse_then_serialize("#project: cams/gkab\n")
-    assert serialized.strip()+"\n" == "#project: cams/gkab\n"
+    text = "#project: cams/gkab\n"
+    serialized = parse_then_serialize(text)
+    assert serialized.strip()+"\n" == text
 
 
 @pytest.mark.skip("test_text_language is not implemented yet")

--- a/pyoracc/test/atf/test_atfserializer.py
+++ b/pyoracc/test/atf/test_atfserializer.py
@@ -26,29 +26,6 @@ from pyoracc.model.line import Line
 from pyoracc.test.fixtures import belsunu
 
 
-def parse(any_str):
-    """
-    Parse input string, could be just a line or a whole file content.
-    """
-    parsed = AtfFile(any_str)
-    return parsed
-
-
-def serialize(any_object):
-    """
-    Serialize input object, from a simple lemma to a whole AtfFile object.
-    """
-    serialized = any_object.serialize()
-    return serialized
-
-
-def parse_then_serialize(any_str):
-    """
-    Shorthand for testing serialization.
-    """
-    return serialize(parse(any_str))
-
-
 def test_belsunu_serializer():
     """
     Parse belsunu.atf, then serialize, parse again, serialize again,
@@ -58,8 +35,8 @@ def test_belsunu_serializer():
     The solution is to parse again the serialized file, serialize again,
     then compare the two serializations.
     """
-    serialized_1 = parse_then_serialize(belsunu())
-    serialized_2 = parse_then_serialize(serialized_1)
+    serialized_1 = AtfFile(belsunu()).serialize()
+    serialized_2 = AtfFile(serialized_1).serialize()
     assert serialized_1 == serialized_2
 
 
@@ -110,8 +87,8 @@ def test_text_code_and_description():
     of ATF texts.
     """
     text = "&X001001 = JCS 48, 089\n"
-    atf = parse(text)
-    serialized = serialize(atf)
+    atf = AtfFile(text)
+    serialized = atf.serialize()
     assert serialized.strip()+"\n" == text
 
 
@@ -121,7 +98,7 @@ def test_text_project():
     Check if serializing works for the project lines.
     """
     text = "#project: cams/gkab\n"
-    serialized = parse_then_serialize(text)
+    serialized = AtfFile(text).serialize()
     assert serialized.strip()+"\n" == text
 
 


### PR DESCRIPTION
Remove unittest dependency, addressing #82, which unblocks adding travis jobs for current and upcoming python releases.